### PR TITLE
downgraded cryptography version due to impossibility to install newer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2022-03-13
+
+### Changed
+
+- downgraded cryptography version @tropxy in https://github.com/SwitchEV/iso15118/pull/23
+
+
 ## [0.2.0] - 2022-02-22
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iso15118"
-version = "0.2.0"
+version = "0.2.1"
 description = "Implementation of the ISO 15118-2 and -20 specs for SECC"
 authors = ["André Duarte <andre@switch-ev.com>",
            "Dr. Marc Mültin <marc@switch-ev.com>"]


### PR DESCRIPTION
downgraded cryptography version due to impossibility to install newer version in arm archs.  

For now, only version 3.4.6 is supported as was not possible to install
more recent versions in arm archs.
An issue related to: https://github.com/pyca/cryptography/issues/6485, which mentions a bug in debian distros:
https://github.com/pyca/cryptography/issues/6485#issuecomment-953544061