### PR TITLE
Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Option 2. Local Installation
    sudo apt update && sudo apt install -y default-jre
    ```
 
-   The JRE engine is only a requirement if using the Java-based
+   The JRE engine is only a requirement in Josev Community if using the Java-based
    EXI codec (EXIficient)[^4]. Josev Professional uses our own Rust-based EXI codec.
 
    For convenience, the Makefile, present in the project, helps you to start up SECC. Thus, in the terminal run:


### PR DESCRIPTION
Have moved things around a little bit in the readme. As people are likely to try things even before reading the whole document, maybe it is better to order them in the preferred order of execution. With that in mind:

-  Have moved the details regarding generation of certificates to before details about running the code. 
-  Have mentioned that JRE is a requirement in Josev Community only if using EXIficient provided. (And a hint that Josev Professional uses Rust based EXI Codec)