### PR TITLE
docs: add details discovered in running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ This means, if development settings are desired, one can simply copy the content
 of `.env.dev.local` to `.env`.
 
 By default, `.env.dev.local` assumes the presence of an `eth0` network interface.
-If you are not using ethernet, replace the `NETWORK_INTERFACE` value in your local `.env`
-file with the one you are using. 
+If you are not using eth0 as your network interface, replace the `NETWORK_INTERFACE` value
+in your local `.env` file with the one you are using.
 
 If Docker is used, the command `make run` will try to get the `.env` file;
 The command `make dev` will fetch the contents of `.env.dev.docker` - thus,


### PR DESCRIPTION
This PR adds some details I learned in trying to get `make run-secc` to succeed in a local installation.

This is meant to be a quick PR with more to follow -- I think this could be restructured some more to make the setup process easier to follow, but will do that in a separate PR.

Another question: does this actually only run on Linux?  If so, do we know why it doesn't run on MacOS?  The final section, "Integration Test with an EV Simulator", indicates that it has been run successfully under Ubuntu, Debian, and MacOS (which versions?)