### PR TITLE
Fix running in docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ cryptography = "3.4.6"
 pydantic = "^1.9.0"
 psutil = "^5.9.0"
 py4j = "^0.10.9"
-
+aiofile = "^3.7.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"
@@ -30,7 +30,6 @@ black = "22.3.0"
 isort = "^5.10.1"
 flake8 = "^4.0.1"
 pytest-cov = "^3.0.0"
-aiofile = "^3.7.4"
 
 [tool.isort]
 profile = "black"

--- a/template.Dockerfile
+++ b/template.Dockerfile
@@ -71,4 +71,4 @@ COPY --from=build /usr/src/app/iso15118/shared/pki/ /usr/src/app/iso15118/shared
 
 
 # This will run the entrypoint script defined in the pyproject.toml
-CMD /venv/bin/iso15118
+CMD sleep 1 && /venv/bin/iso15118


### PR DESCRIPTION
I tested the ISO15118 docker-compose file and ran into a few issues:

1.  ModuleNotFoundError: No module named 'aiofile'
```
secc_1   | Traceback (most recent call last):
secc_1   |   File "/venv/bin/iso15118", line 5, in <module>
secc_1   |     from iso15118.secc.main import run
secc_1   |   File "/venv/lib/python3.10/site-packages/iso15118/secc/main.py", line 5, in <module>
secc_1   |     from iso15118.secc.controller.simulator import SimEVSEController
secc_1   |   File "/venv/lib/python3.10/site-packages/iso15118/secc/controller/simulator.py", line 10, in <module>
secc_1   |     from aiofile import async_open
secc_1   | ModuleNotFoundError: No module named 'aiofile'
```
I fixed this by moving `aiofile` dependency 

2. Cannot assign requested address
```
DEBUG    2022-05-25 11:14:09,547 - asyncio (59): Using selector: EpollSelector
INFO    2022-05-25 11:14:10,257 - iso15118.shared.exi_codec (168): EXI Codec version: 1.55
INFO    2022-05-25 11:14:10,257 - iso15118.secc.comm_session_handler (196): Communication session handler started
INFO    2022-05-25 11:14:10,260 - iso15118.secc.transport.udp_server (110): UDP server socket ready
INFO    2022-05-25 11:14:10,260 - iso15118.secc.transport.udp_server (97): UDP server started at address FF02::1%eth0 and port 15118
ERROR    2022-05-25 11:14:10,260 - iso15118.shared.utils (78): [Errno 99] Cannot assign requested address
Traceback (most recent call last):
  File "/venv/lib/python3.10/site-packages/iso15118/shared/utils.py", line 76, in wait_till_finished
    task.result()
  File "/venv/lib/python3.10/site-packages/iso15118/secc/transport/tcp_server.py", line 39, in start_tls
    await self.server_factory(tls=True)
  File "/venv/lib/python3.10/site-packages/iso15118/secc/transport/tcp_server.py", line 97, in server_factory
    sock.bind(self.full_ipv6_address)
OSError: [Errno 99] Cannot assign requested address
ERROR    2022-05-25 11:14:10,261 - iso15118.shared.utils (78): [Errno 99] Cannot assign requested address
Traceback (most recent call last):
  File "/venv/lib/python3.10/site-packages/iso15118/shared/utils.py", line 76, in wait_till_finished
    task.result()
  File "/venv/lib/python3.10/site-packages/iso15118/secc/transport/tcp_server.py", line 45, in start_no_tls
    await self.server_factory(tls=False)
  File "/venv/lib/python3.10/site-packages/iso15118/secc/transport/tcp_server.py", line 97, in server_factory
    sock.bind(self.full_ipv6_address)
OSError: [Errno 99] Cannot assign requested address
ERROR    2022-05-25 11:14:10,261 - iso15118.secc (35): SECC terminated: 
```
After i added a sleep of 1 sec before running the executable i got this:
the `TLS server started at ..` and `TCP server started at ..` is the docker container network not yet started when the execuable is ran?


### used setup
Pop!_OS 21.10 
Docker version 20.10.12, build e91ed57
docker-compose version 1.29.2, build 5becea4c

