### PR TITLE
fix: authorization state enum

### DIFF
--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -163,9 +163,9 @@ class EVSEControllerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def is_authorised(self) -> bool:
+    def is_authorized(self) -> bool:
         """
-        Provides the information on whether or not the user is authorised to charge at
+        Provides the information on whether or not the user is authorized to charge at
         this EVSE. The auth token could be an RFID card, a whitelisted MAC address
         of the EV (Autocharge), a contract certificate (Plug & Charge), or a payment
         authorization via NFC or credit card.

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -21,7 +21,7 @@ from iso15118.shared.messages.datatypes import (
 from iso15118.shared.messages.din_spec.datatypes import (
     SAScheduleTupleEntry as SAScheduleTupleEntryDINSPEC,
 )
-from iso15118.shared.messages.enums import Contactor, EnergyTransferModeEnum, Protocol
+from iso15118.shared.messages.enums import AuthorizationStatus, Contactor, EnergyTransferModeEnum, Protocol
 from iso15118.shared.messages.iso15118_2.datatypes import (
     ACEVSEChargeParameter,
     ACEVSEStatus,
@@ -163,7 +163,7 @@ class EVSEControllerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def is_authorized(self) -> bool:
+    def is_authorized(self) -> AuthorizationStatus:
         """
         Provides the information on whether or not the user is authorized to charge at
         this EVSE. The auth token could be an RFID card, a whitelisted MAC address

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -21,7 +21,12 @@ from iso15118.shared.messages.datatypes import (
 from iso15118.shared.messages.din_spec.datatypes import (
     SAScheduleTupleEntry as SAScheduleTupleEntryDINSPEC,
 )
-from iso15118.shared.messages.enums import AuthorizationStatus, Contactor, EnergyTransferModeEnum, Protocol
+from iso15118.shared.messages.enums import (
+    AuthorizationStatus,
+    Contactor,
+    EnergyTransferModeEnum,
+    Protocol,
+)
 from iso15118.shared.messages.iso15118_2.datatypes import (
     ACEVSEChargeParameter,
     ACEVSEStatus,

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -42,6 +42,7 @@ from iso15118.shared.messages.din_spec.datatypes import (
     SAScheduleTupleEntry as SAScheduleTupleEntryDINSPEC,
 )
 from iso15118.shared.messages.enums import (
+    AuthorizationStatus,
     Contactor,
     EnergyTransferModeEnum,
     IsolationLevel,
@@ -388,9 +389,9 @@ class SimEVSEController(EVSEControllerInterface):
 
         return service_list
 
-    def is_authorised(self) -> bool:
-        """Overrides EVSEControllerInterface.is_authorised()."""
-        return True
+    def is_authorized(self) -> AuthorizationStatus:
+        """Overrides EVSEControllerInterface.is_authorized()."""
+        return AuthorizationStatus.AUTHORIZED
 
     def get_sa_schedule_list_dinspec(
         self, max_schedule_entries: Optional[int], departure_time: int = 0

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -391,7 +391,7 @@ class SimEVSEController(EVSEControllerInterface):
 
     def is_authorized(self) -> AuthorizationStatus:
         """Overrides EVSEControllerInterface.is_authorized()."""
-        return AuthorizationStatus.AUTHORIZED
+        return AuthorizationStatus.ACCEPTED
 
     def get_sa_schedule_list_dinspec(
         self, max_schedule_entries: Optional[int], departure_time: int = 0

--- a/iso15118/secc/states/din_spec_states.py
+++ b/iso15118/secc/states/din_spec_states.py
@@ -51,6 +51,7 @@ from iso15118.shared.messages.din_spec.msgdef import V2GMessage as V2GMessageDIN
 from iso15118.shared.messages.din_spec.timeouts import Timeouts
 from iso15118.shared.messages.enums import (
     AuthEnum,
+    AuthorizationStatus,
     DCEVErrorCode,
     EVSEProcessing,
     IsolationLevel,
@@ -304,7 +305,7 @@ class ContractAuthentication(StateSECC):
 
         evse_processing = EVSEProcessing.ONGOING
         next_state: Type["State"] = None
-        if self.comm_session.evse_controller.is_authorised():
+        if self.comm_session.evse_controller.is_authorized() == AuthorizationStatus.ACCEPTED:
             evse_processing = EVSEProcessing.FINISHED
             next_state = ChargeParameterDiscovery
 

--- a/iso15118/secc/states/din_spec_states.py
+++ b/iso15118/secc/states/din_spec_states.py
@@ -305,7 +305,10 @@ class ContractAuthentication(StateSECC):
 
         evse_processing = EVSEProcessing.ONGOING
         next_state: Type["State"] = None
-        if self.comm_session.evse_controller.is_authorized() == AuthorizationStatus.ACCEPTED:
+        if (
+            self.comm_session.evse_controller.is_authorized()
+            == AuthorizationStatus.ACCEPTED
+        ):
             evse_processing = EVSEProcessing.FINISHED
             next_state = ChargeParameterDiscovery
 

--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -18,6 +18,7 @@ from iso15118.shared.messages.app_protocol import (
 from iso15118.shared.messages.din_spec.msgdef import V2GMessage as V2GMessageDINSPEC
 from iso15118.shared.messages.enums import (
     AuthEnum,
+    AuthorizationStatus,
     Contactor,
     ControlMode,
     ISOV20PayloadTypes,
@@ -377,10 +378,19 @@ class Authorization(StateSECC):
             if auth_req.pnc_params.gen_challenge != self.comm_session.gen_challenge:
                 response_code = ResponseCode.WARN_CHALLENGE_INVALID
 
-        if self.comm_session.evse_controller.is_authorised():
+        if (
+            self.comm_session.evse_controller.is_authorized() == (
+                AuthorizationStatus.ACCEPTED
+            )
+        ):
             auth_status = Processing.FINISHED
-        else:
+        elif (
+            self.comm_session.evse_controller.is_authorized() == (
+                AuthorizationStatus.ONGOING
+            )
+        ):
             auth_status = Processing.ONGOING
+        # TODO Handle REJECTED case?
         # TODO Need to distinguish between ONGOING and WAITING_FOR_CUSTOMER
 
         auth_res = AuthorizationRes(

--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -386,7 +386,7 @@ class Authorization(StateSECC):
             AuthorizationStatus.ONGOING
         ):
             auth_status = Processing.ONGOING
-        # TODO Handle REJECTED case?
+        # TODO GitHub#56 Handle REJECTED case
         # TODO Need to distinguish between ONGOING and WAITING_FOR_CUSTOMER
 
         auth_res = AuthorizationRes(

--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -378,16 +378,12 @@ class Authorization(StateSECC):
             if auth_req.pnc_params.gen_challenge != self.comm_session.gen_challenge:
                 response_code = ResponseCode.WARN_CHALLENGE_INVALID
 
-        if (
-            self.comm_session.evse_controller.is_authorized() == (
-                AuthorizationStatus.ACCEPTED
-            )
+        if self.comm_session.evse_controller.is_authorized() == (
+            AuthorizationStatus.ACCEPTED
         ):
             auth_status = Processing.FINISHED
-        elif (
-            self.comm_session.evse_controller.is_authorized() == (
-                AuthorizationStatus.ONGOING
-            )
+        elif self.comm_session.evse_controller.is_authorized() == (
+            AuthorizationStatus.ONGOING
         ):
             auth_status = Processing.ONGOING
         # TODO Handle REJECTED case?

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -892,6 +892,7 @@ class Authorization(StateSECC):
             auth_status = EVSEProcessing.FINISHED
             next_state = ChargeParameterDiscovery
 
+        # TODO GitHub#54: handle REJECTED case
         # TODO Need to distinguish between ONGOING and
         #      ONGOING_WAITING_FOR_CUSTOMER
 

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -886,10 +886,8 @@ class Authorization(StateSECC):
 
         auth_status: EVSEProcessing = EVSEProcessing.ONGOING
         next_state: Type["State"] = Authorization
-        if (
-            self.comm_session.evse_controller.is_authorized() == (
-                AuthorizationStatus.ACCEPTED
-            )
+        if self.comm_session.evse_controller.is_authorized() == (
+            AuthorizationStatus.ACCEPTED
         ):
             auth_status = EVSEProcessing.FINISHED
             next_state = ChargeParameterDiscovery

--- a/iso15118/shared/messages/enums.py
+++ b/iso15118/shared/messages/enums.py
@@ -39,6 +39,23 @@ class AuthEnum(str, Enum):
     PNC_V2 = "Contract"
 
 
+class AuthorizationStatus(str, Enum):
+    """Whether an authorization request is accepted, rejected, or is ongoing.
+
+    An ISO 15118 authorization response can be Accepted, Rejected, or
+    Ongoing, since sending a request multiple times is used as a workaround
+    for very short timeouts required in the ISO 15118-2 spec.
+    For example, AuthorizationReq has a timeout of 2 seconds.
+    For further detail, see 8.7.2.1 Definitions, tables 108-110, pp. 171-73,
+    in the ISO 15118-2 specification.
+
+    In DIN SPEC 70121, only Accepted and Rejected should be used.
+    """
+    ACCEPTED = "Accepted"
+    REJECTED = "Rejected"
+    ONGOING = "Ongoing"
+
+
 class EnergyTransferModeEnum(str, Enum):
     """
     This enum is shared between DIN SPEC 70121 and ISO 15118-2

--- a/iso15118/shared/messages/enums.py
+++ b/iso15118/shared/messages/enums.py
@@ -51,6 +51,7 @@ class AuthorizationStatus(str, Enum):
 
     In DIN SPEC 70121, only Accepted and Rejected should be used.
     """
+
     ACCEPTED = "Accepted"
     REJECTED = "Rejected"
     ONGOING = "Ongoing"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,13 @@ from iso15118.shared.messages.enums import Protocol
 from iso15118.shared.messages.iso15118_2.datatypes import EnergyTransferModeEnum
 from iso15118.shared.notifications import StopNotification
 from tests.secc.states.test_messages import get_sa_schedule_list
+from tests.tools import MOCK_SESSION_ID
 
 
 @pytest.fixture
 def comm_evcc_session_mock():
     comm_session_mock = Mock(spec=EVCCCommunicationSession)
-    comm_session_mock.session_id = "F9F9EE8505F55838"
+    comm_session_mock.session_id = MOCK_SESSION_ID
     comm_session_mock.stop_reason = StopNotification(False, "pytest")
     comm_session_mock.ev_controller = SimEVController()
     comm_session_mock.protocol = Protocol.UNKNOWN
@@ -28,7 +29,7 @@ def comm_evcc_session_mock():
 @pytest.fixture
 def comm_secc_session_mock():
     comm_session_mock = Mock(spec=SECCCommunicationSession)
-    comm_session_mock.session_id = "F9F9EE8505F55838"
+    comm_session_mock.session_id = MOCK_SESSION_ID
     comm_session_mock.offered_schedules = get_sa_schedule_list()
     comm_session_mock.selected_energy_mode = EnergyTransferModeEnum.DC_EXTENDED
     comm_session_mock.selected_charging_type_is_ac = False

--- a/tests/dinspec/evcc/evcc_mock_messages.py
+++ b/tests/dinspec/evcc/evcc_mock_messages.py
@@ -45,6 +45,7 @@ from iso15118.shared.messages.enums import (
     EnergyTransferModeEnum,
     EVSEProcessing,
 )
+from tests.tools import MOCK_SESSION_ID
 
 
 def get_dc_evse_status():
@@ -143,7 +144,7 @@ def get_failed_current_demand_acheived():
         evse_power_limit_achieved=(is_evse_power_limit_achieved()),
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(current_demand_res=current_demand_res),
     )
 
@@ -163,7 +164,7 @@ def get_service_discovery_message_payment_service_not_offered():
         charge_service=charge_service,
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(service_discovery_res=service_discovery_res),
     )
 
@@ -183,7 +184,7 @@ def get_service_discovery_message_charge_service_not_offered():
         charge_service=charge_service,
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(service_discovery_res=service_discovery_res),
     )
 
@@ -203,7 +204,7 @@ def get_service_discovery_message():
         charge_service=charge_service,
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(service_discovery_res=service_discovery_res),
     )
 
@@ -219,7 +220,7 @@ def get_current_demand_acheived():
         evse_power_limit_achieved=(is_evse_power_limit_achieved()),
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(current_demand_res=current_demand_res),
     )
 
@@ -238,7 +239,7 @@ def get_v2g_message_current_demand_current_limit_not_achieved():
         evse_max_power_limit=PVEVSEMaxPowerLimit(multiplier=1, value=1000, unit="W"),
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(current_demand_res=current_demand_res),
     )
 
@@ -248,7 +249,7 @@ def get_service_payment_selection_message():
         response_code=ResponseCode.OK
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(service_payment_selection_res=service_payment_selection_message),
     )
 
@@ -258,7 +259,7 @@ def get_service_payment_selection_fail_message():
         response_code=ResponseCode.FAILED_PAYMENT_SELECTION_INVALID
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(service_payment_selection_res=service_payment_selection_message),
     )
 
@@ -268,7 +269,7 @@ def get_contract_authentication_message():
         response_code=ResponseCode.OK, evse_processing=EVSEProcessing.FINISHED
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(contract_authentication_res=contract_authentication_message),
     )
 
@@ -278,7 +279,7 @@ def get_contract_authentication_ongoing_message():
         response_code=ResponseCode.OK, evse_processing=EVSEProcessing.ONGOING
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(contract_authentication_res=contract_authentication_message),
     )
 
@@ -297,7 +298,7 @@ def get_charge_parameter_discovery_on_going_message():
         )
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(charge_parameter_discovery_res=charge_parameter_discovery_res),
     )
 
@@ -316,7 +317,7 @@ def get_charge_parameter_discovery_message():
         )
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(charge_parameter_discovery_res=charge_parameter_discovery_res),
     )
 
@@ -327,7 +328,7 @@ def get_power_delivery_res_message():
         dc_evse_status=get_dc_evse_status(),
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(power_delivery_res=power_delivery_res),
     )
 
@@ -339,6 +340,6 @@ def get_welding_detection_on_going_message():
         evse_present_voltage=get_evse_present_voltage(),
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(welding_detection_res=welding_detection),
     )

--- a/tests/dinspec/secc/secc_mock_messages.py
+++ b/tests/dinspec/secc/secc_mock_messages.py
@@ -14,6 +14,7 @@ from iso15118.shared.messages.din_spec.datatypes import DCEVStatus
 from iso15118.shared.messages.din_spec.header import MessageHeader
 from iso15118.shared.messages.din_spec.msgdef import V2GMessage
 from iso15118.shared.messages.enums import DCEVErrorCode, UnitSymbol
+from tests.tools import MOCK_SESSION_ID
 
 
 def get_dc_ev_status() -> DCEVStatus:
@@ -71,6 +72,6 @@ def build_dummy_current_demand_req() -> CurrentDemandReq:
 def get_current_on_going_req():
     current_demand_req = build_dummy_current_demand_req()
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(current_demand_req=current_demand_req),
     )

--- a/tests/evcc/states/test_messages.py
+++ b/tests/evcc/states/test_messages.py
@@ -17,6 +17,7 @@ from iso15118.shared.messages.iso15118_2.body import (
 from iso15118.shared.messages.iso15118_2.datatypes import ResponseCode
 from iso15118.shared.messages.iso15118_2.header import MessageHeader
 from iso15118.shared.messages.iso15118_2.msgdef import V2GMessage
+from tests.tools import MOCK_SESSION_ID
 
 
 def get_dc_evse_status():
@@ -45,7 +46,7 @@ def get_v2g_message_current_demand_res():
         receipt_required=False,
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(current_demand_res=current_demand_res),
     )
 
@@ -64,6 +65,6 @@ def get_v2g_message_power_delivery_res():
         dc_evse_status=get_dc_evse_status(),
     )
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(power_delivery_res=power_delivery_res),
     )

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -3,11 +3,15 @@ from unittest.mock import Mock, patch
 import pytest
 
 from iso15118.secc.states.iso15118_2_states import (
+    Authorization,
+    ChargeParameterDiscovery,
     CurrentDemand,
     PowerDelivery,
     WeldingDetection,
 )
+from iso15118.shared.messages.enums import AuthEnum
 from tests.secc.states.test_messages import (
+    get_dummy_v2g_message_authorization_req,
     get_dummy_v2g_message_welding_detection_req,
     get_v2g_message_power_delivery_req,
 )
@@ -44,3 +48,17 @@ class TestEvScenarios:
     ):
         pass
         # V2G2-570
+
+    async def test_authorization_to_parameter_discovery_when_authorization_accepted(
+        self,
+    ):
+        self.comm_session.selected_auth_option = AuthEnum.EIM
+        authorization = Authorization(self.comm_session)
+        authorization.process_message(message=get_dummy_v2g_message_authorization_req())
+        assert isinstance(self.comm_session.current_state, ChargeParameterDiscovery)
+
+    async def test_authorization_to_authorization_when_authorization_ongoing(self):
+        assert False
+
+    async def test_authorization_to_authorization_when_authorization_rejected(self):
+        assert False

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -59,7 +59,10 @@ class TestEvScenarios:
             pytest.param(
                 AuthorizationStatus.REJECTED,
                 Terminate,
-                marks=pytest.mark.xfail(reason="REJECTED handling not implemented yet"),
+                marks=pytest.mark.xfail(
+                    reason="REJECTED handling not implemented yet; "
+                    "see GitHub issue #54",
+                ),
             ),
         ],
     )

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -7,6 +7,7 @@ from iso15118.secc.states.iso15118_2_states import (
     ChargeParameterDiscovery,
     CurrentDemand,
     PowerDelivery,
+    Terminate,
     WeldingDetection,
 )
 from iso15118.secc.states.secc_state import StateSECC
@@ -55,7 +56,11 @@ class TestEvScenarios:
         [
             (AuthorizationStatus.ACCEPTED, ChargeParameterDiscovery),
             (AuthorizationStatus.ONGOING, Authorization),
-            (AuthorizationStatus.REJECTED, Authorization),
+            pytest.param(
+                AuthorizationStatus.REJECTED,
+                Terminate,
+                marks=pytest.mark.xfail(reason="REJECTED handling not implemented yet"),
+            ),
         ],
     )
     async def test_authorization_next_state_on_authorization_request(

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -65,7 +65,7 @@ class TestEvScenarios:
     ):
         self.comm_session.selected_auth_option = AuthEnum.EIM
         mock_is_authorized = Mock(return_value=is_authorized_return_value)
-        self.comm_session.evse_controller.is_authorized = mock_is_authorized 
+        self.comm_session.evse_controller.is_authorized = mock_is_authorized
         authorization = Authorization(self.comm_session)
         authorization.process_message(message=get_dummy_v2g_message_authorization_req())
         assert authorization.next_state == expected_next_state

--- a/tests/secc/states/test_messages.py
+++ b/tests/secc/states/test_messages.py
@@ -2,6 +2,7 @@ from typing import List
 
 from iso15118.shared.messages.enums import UnitSymbol
 from iso15118.shared.messages.iso15118_2.body import (
+    AuthorizationReq,
     Body,
     PowerDeliveryReq,
     SessionStopReq,
@@ -101,4 +102,16 @@ def get_dummy_v2g_message_session_stop_req():
     return V2GMessage(
         header=MessageHeader(session_id="F9F9EE8505F55838"),
         body=Body(session_stop_req=session_stop_req),
+    )
+
+
+def get_dummy_v2g_message_authorization_req():
+    # The AuthorizationReq is empty, unless it is following a PaymentDetailsRes
+    # message, in which case it must send back the generated challenge.
+    authorization_req = AuthorizationReq()
+
+    # TODO: replace this with a constant
+    return V2GMessage(
+        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        body=Body(authorization_req=authorization_req),
     )

--- a/tests/secc/states/test_messages.py
+++ b/tests/secc/states/test_messages.py
@@ -23,6 +23,7 @@ from iso15118.shared.messages.iso15118_2.datatypes import (
 )
 from iso15118.shared.messages.iso15118_2.header import MessageHeader
 from iso15118.shared.messages.iso15118_2.msgdef import V2GMessage
+from tests.tools import MOCK_SESSION_ID
 
 
 def get_sa_schedule_list():
@@ -70,7 +71,7 @@ def get_v2g_message_power_delivery_req():
     )
 
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(power_delivery_req=power_delivery_req),
     )
 
@@ -89,7 +90,7 @@ def get_dummy_v2g_message_welding_detection_req():
     )
 
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(welding_detection_req=welding_detection_req),
     )
 
@@ -100,7 +101,7 @@ def get_dummy_v2g_message_session_stop_req():
     )
 
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(session_stop_req=session_stop_req),
     )
 
@@ -110,8 +111,7 @@ def get_dummy_v2g_message_authorization_req():
     # message, in which case it must send back the generated challenge.
     authorization_req = AuthorizationReq()
 
-    # TODO: replace this with a constant
     return V2GMessage(
-        header=MessageHeader(session_id="F9F9EE8505F55838"),
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(authorization_req=authorization_req),
     )

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,0 +1,2 @@
+"""Test helper classes and functions."""
+MOCK_SESSION_ID = "F9F9EE8505F55838"


### PR DESCRIPTION
This PR replaces the true/false return value for `is_authorized` with Accepted/Rejected/Ongoing, since an AuthorizationReq can be retried to deal with the time limit imposed by ISO 15118-2.

This also adds some unit tests and replaces a repeatedly-used test value with a constant.