### PR TITLE
fix: Sum of durations in schedule entries must match departure_time from EVCC (AB#2183)

### DIFF
--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -3,6 +3,7 @@ This module contains the code to retrieve (hardware-related) data from the EVSE
 (Electric Vehicle Supply Equipment).
 """
 import logging
+import math
 import time
 from dataclasses import dataclass
 from typing import List, Optional
@@ -420,21 +421,40 @@ class SimEVSEController(EVSEControllerInterface):
         """Overrides EVSEControllerInterface.get_sa_schedule_list()."""
         sa_schedule_list: List[SAScheduleTuple] = []
 
+        if departure_time == 0:
+            # [V2G2-304] If no departure_time is provided, the sum of the individual
+            # time intervals shall be greater than or equal to 24 hours.
+            departure_time = 86400
+
         # PMaxSchedule
-        p_max = PVPMax(multiplier=0, value=11000, unit=UnitSymbol.WATT)
-        p_max_schedule_entry = PMaxScheduleEntry(
-            p_max=p_max, time_interval=RelativeTimeInterval(start=0, duration=3600)
+        p_max_1 = PVPMax(multiplier=0, value=11000, unit=UnitSymbol.WATT)
+        p_max_2 = PVPMax(multiplier=0, value=7000, unit=UnitSymbol.WATT)
+        p_max_schedule_entry_1 = PMaxScheduleEntry(
+            p_max=p_max_1, time_interval=RelativeTimeInterval(start=0)
         )
-        p_max_schedule = PMaxSchedule(schedule_entries=[p_max_schedule_entry])
+        p_max_schedule_entry_2 = PMaxScheduleEntry(
+            p_max=p_max_2,
+            time_interval=RelativeTimeInterval(
+                start=math.floor(departure_time / 2),
+                duration=math.ceil(departure_time / 2),
+            ),
+        )
+        p_max_schedule = PMaxSchedule(
+            schedule_entries=[p_max_schedule_entry_1, p_max_schedule_entry_2]
+        )
 
         # SalesTariff
         sales_tariff_entries: List[SalesTariffEntry] = []
         sales_tariff_entry_1 = SalesTariffEntry(
-            e_price_level=1, time_interval=RelativeTimeInterval(start=0)
+            e_price_level=1,
+            time_interval=RelativeTimeInterval(start=math.floor(departure_time / 2)),
         )
         sales_tariff_entry_2 = SalesTariffEntry(
             e_price_level=2,
-            time_interval=RelativeTimeInterval(start=1801, duration=1799),
+            time_interval=RelativeTimeInterval(
+                start=math.floor(departure_time / 2),
+                duration=math.ceil(departure_time / 2),
+            ),
         )
         sales_tariff_entries.append(sales_tariff_entry_1)
         sales_tariff_entries.append(sales_tariff_entry_2)

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -13,6 +13,8 @@ from iso15118.secc.states.iso15118_2_states import (
 from iso15118.secc.states.secc_state import StateSECC
 from iso15118.shared.messages.enums import AuthEnum, AuthorizationStatus
 from tests.secc.states.test_messages import (
+    get_charge_parameter_discovery_req_message_departure_time_one_hour,
+    get_charge_parameter_discovery_req_message_no_departure_time,
     get_dummy_v2g_message_authorization_req,
     get_dummy_v2g_message_welding_detection_req,
     get_v2g_message_power_delivery_req,
@@ -77,3 +79,110 @@ class TestEvScenarios:
         authorization = Authorization(self.comm_session)
         authorization.process_message(message=get_dummy_v2g_message_authorization_req())
         assert authorization.next_state == expected_next_state
+
+    async def test_charge_parameter_discovery_res_v2g2_303(self):
+        # V2G2-303 : Sum of individual time intervals shall match the period of time
+        # indicated by the EVCC.
+        charge_parameter_discovery = ChargeParameterDiscovery(self.comm_session)
+
+        charge_parameter_discovery_req_departure_time_set = (
+            get_charge_parameter_discovery_req_message_departure_time_one_hour()
+        )
+        charge_parameter_discovery.process_message(
+            message=charge_parameter_discovery_req_departure_time_set
+        )
+
+        charging_duration = (
+            charge_parameter_discovery_req_departure_time_set.body.charge_parameter_discovery_req.ac_ev_charge_parameter.departure_time  # noqa
+        )
+
+        assert (
+            charge_parameter_discovery.next_msg.body.charge_parameter_discovery_res
+            is not None
+        )
+        charge_parameter_discovery_res = (
+            charge_parameter_discovery.next_msg.body.charge_parameter_discovery_res
+        )
+        assert charge_parameter_discovery_res.sa_schedule_list is not None
+        sa_schedule_tuples = (
+            charge_parameter_discovery_res.sa_schedule_list.schedule_tuples
+        )
+        for schedule_tuples in sa_schedule_tuples:
+            assert schedule_tuples.p_max_schedule is not None
+            schedule_duration = 0
+            if schedule_tuples.p_max_schedule.schedule_entries is not None:
+                start_time = schedule_tuples.p_max_schedule.schedule_entries[
+                    0
+                ].time_interval.start
+
+            for entry in schedule_tuples.p_max_schedule.schedule_entries:
+                schedule_duration += entry.time_interval.start - start_time
+                if entry.time_interval.duration is not None:
+                    schedule_duration += entry.time_interval.duration
+                start_time = entry.time_interval.start
+            assert schedule_duration == charging_duration
+
+    async def test_charge_parameter_discovery_res_v2g2_304(self):
+        # V2G2-304: If departure time was not provided, then sum of time intervals
+        # in PMaxSchedule shall be greater than or equal to 24 hours.
+        twenty_four_hours_in_seconds = 86400
+        charge_parameter_discovery = ChargeParameterDiscovery(self.comm_session)
+        charge_parameter_discovery.process_message(
+            message=get_charge_parameter_discovery_req_message_no_departure_time()
+        )
+        assert (
+            charge_parameter_discovery.next_msg.body.charge_parameter_discovery_res
+            is not None
+        )
+        charge_parameter_discovery_res = (
+            charge_parameter_discovery.next_msg.body.charge_parameter_discovery_res
+        )
+        assert charge_parameter_discovery_res.sa_schedule_list is not None
+        schedule_tuples = (
+            charge_parameter_discovery_res.sa_schedule_list.schedule_tuples
+        )
+
+        for schedule_tuple in schedule_tuples:
+            schedule_duration = 0
+            if schedule_tuple.p_max_schedule.schedule_entries is not None:
+                start_time = schedule_tuple.p_max_schedule.schedule_entries[
+                    0
+                ].time_interval.start
+
+            for entry in schedule_tuple.p_max_schedule.schedule_entries:
+                schedule_duration += entry.time_interval.start - start_time
+                if entry.time_interval.duration is not None:
+                    schedule_duration += entry.time_interval.duration
+                start_time = entry.time_interval.start
+            assert schedule_duration >= twenty_four_hours_in_seconds
+
+    async def test_charge_parameter_discovery_res_v2g2_761(self):
+        # V2G2-761: If departure time was not provided, then SECC shall assume
+        # that the EV intends to start charging without any delay
+        charge_parameter_discovery = ChargeParameterDiscovery(self.comm_session)
+        charge_parameter_discovery.process_message(
+            message=get_charge_parameter_discovery_req_message_no_departure_time()
+        )
+        assert (
+            charge_parameter_discovery.next_msg.body.charge_parameter_discovery_res
+            is not None
+        )
+        charge_parameter_discovery_res = (
+            charge_parameter_discovery.next_msg.body.charge_parameter_discovery_res
+        )
+
+        assert charge_parameter_discovery_res.sa_schedule_list is not None
+        sa_schedule_tuples = (
+            charge_parameter_discovery_res.sa_schedule_list.schedule_tuples
+        )
+
+        for schedule_tuples in sa_schedule_tuples:
+            assert schedule_tuples.p_max_schedule is not None
+            found_entry_indicating_start_without_delay = False
+            duration_indicating_immediate_start = 30
+            for entry in schedule_tuples.p_max_schedule.schedule_entries:
+                if entry.time_interval.start < duration_indicating_immediate_start:
+                    found_entry_indicating_start_without_delay = True
+                    break
+
+            assert found_entry_indicating_start_without_delay is True

--- a/tests/secc/states/test_messages.py
+++ b/tests/secc/states/test_messages.py
@@ -1,14 +1,22 @@
 from typing import List
 
-from iso15118.shared.messages.enums import UnitSymbol
+from iso15118.shared.messages.datatypes import (
+    PVEAmount,
+    PVEVMaxCurrent,
+    PVEVMaxVoltage,
+    PVEVMinCurrent,
+)
+from iso15118.shared.messages.enums import EnergyTransferModeEnum, UnitSymbol
 from iso15118.shared.messages.iso15118_2.body import (
     AuthorizationReq,
     Body,
+    ChargeParameterDiscoveryReq,
     PowerDeliveryReq,
     SessionStopReq,
     WeldingDetectionReq,
 )
 from iso15118.shared.messages.iso15118_2.datatypes import (
+    ACEVChargeParameter,
     ChargeProgress,
     ChargingSession,
     DCEVErrorCode,
@@ -114,4 +122,54 @@ def get_dummy_v2g_message_authorization_req():
     return V2GMessage(
         header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(authorization_req=authorization_req),
+    )
+
+
+def get_charge_parameter_discovery_req_message_departure_time_one_hour():
+    e_amount = PVEAmount(multiplier=0, value=60, unit=UnitSymbol.WATT_HOURS)
+    ev_max_voltage = PVEVMaxVoltage(multiplier=0, value=400, unit=UnitSymbol.VOLTAGE)
+    ev_max_current = PVEVMaxCurrent(multiplier=-3, value=32000, unit=UnitSymbol.AMPERE)
+    ev_min_current = PVEVMinCurrent(multiplier=0, value=10, unit=UnitSymbol.AMPERE)
+    one_hour_in_seconds = 3
+    ac_charge_params = ACEVChargeParameter(
+        departure_time=one_hour_in_seconds,
+        e_amount=e_amount,
+        ev_max_voltage=ev_max_voltage,
+        ev_max_current=ev_max_current,
+        ev_min_current=ev_min_current,
+    )
+
+    charge_parameter_discovery_req = ChargeParameterDiscoveryReq(
+        requested_energy_mode=EnergyTransferModeEnum.AC_THREE_PHASE_CORE,
+        ac_ev_charge_parameter=ac_charge_params,
+        dc_ev_charge_parameter=None,
+    )
+
+    return V2GMessage(
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
+        body=Body(charge_parameter_discovery_req=charge_parameter_discovery_req),
+    )
+
+
+def get_charge_parameter_discovery_req_message_no_departure_time():
+    e_amount = PVEAmount(multiplier=0, value=60, unit=UnitSymbol.WATT_HOURS)
+    ev_max_voltage = PVEVMaxVoltage(multiplier=0, value=400, unit=UnitSymbol.VOLTAGE)
+    ev_max_current = PVEVMaxCurrent(multiplier=-3, value=32000, unit=UnitSymbol.AMPERE)
+    ev_min_current = PVEVMinCurrent(multiplier=0, value=10, unit=UnitSymbol.AMPERE)
+    ac_charge_params = ACEVChargeParameter(
+        e_amount=e_amount,
+        ev_max_voltage=ev_max_voltage,
+        ev_max_current=ev_max_current,
+        ev_min_current=ev_min_current,
+    )
+
+    charge_parameter_discovery_req = ChargeParameterDiscoveryReq(
+        requested_energy_mode=EnergyTransferModeEnum.AC_THREE_PHASE_CORE,
+        ac_ev_charge_parameter=ac_charge_params,
+        dc_ev_charge_parameter=None,
+    )
+
+    return V2GMessage(
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
+        body=Body(charge_parameter_discovery_req=charge_parameter_discovery_req),
     )


### PR DESCRIPTION
- Added a validation function to check if the schedule returned by the secondary actor is valid
- V2G2-303/304 doesn't seem to be strict though - as V2G2-305 provides provision to EVCC  to renegotiate a new schedule in case duration/sales tariff needs are not met.
- Added tests for V2G2-303, V2G2-304 and V2G2-761