### PR TITLE
feat: Update create_certs.sh to help testing with Keysight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ venv.bak/
 *.p12
 iso15118/shared/pki/iso15118_2
 iso15118/shared/pki/iso15118_20
+/iso15118/shared/pki/pki-ext/


### PR DESCRIPTION
Added an extra command-line option -k to help generate certificates with names as expected by Keysight to help with testing. The certificates generated could be directly pasted into the generated-pki/pki-ext folder in TTWorkbench environment.