### PR TITLE
fix: wrong message parameters will return FAILED_WRONG_CHARGE_PARAMETER

### DIFF
--- a/iso15118/shared/comm_session.py
+++ b/iso15118/shared/comm_session.py
@@ -19,6 +19,7 @@ from iso15118.shared.exceptions import (
     FaultyStateImplementationError,
     InvalidV2GTPMessageError,
     MessageProcessingError,
+    V2GMessageValidationError,
 )
 from iso15118.shared.exi_codec import EXI
 from iso15118.shared.messages.app_protocol import (
@@ -204,6 +205,15 @@ class SessionStateMachine(ABC):
                 f"{self.get_exi_ns(v2gtp_msg.payload_type).value}"
             )
 
+        except V2GMessageValidationError as exc:
+            self.comm_session.current_state.stop_state_machine(
+                exc.reason,
+                None,
+                exc.response_code,
+                exc.message,
+                self.get_exi_ns(v2gtp_msg.payload_type),
+            )
+            return
         except EXIDecodingError as exc:
             logger.exception(f"{exc}")
             raise exc

--- a/iso15118/shared/exceptions.py
+++ b/iso15118/shared/exceptions.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from iso15118.shared.messages.iso15118_2.datatypes import ResponseCode
+
 
 class InvalidInterfaceError(Exception):
     """
@@ -235,3 +237,13 @@ class OCSPServerNotFoundError(Exception):
             self,
             "No OCSP server entry in Authority Information Access extension field.",
         )
+
+
+class V2GMessageValidationError(Exception):
+    """Is thrown if message validation is failed"""
+
+    def __init__(self, reason: str, response_code: ResponseCode, message: Any):
+        Exception.__init__(self)
+        self.reason = reason
+        self.response_code = response_code
+        self.message = message

--- a/iso15118/shared/exi_codec.py
+++ b/iso15118/shared/exi_codec.py
@@ -6,7 +6,11 @@ from typing import Union
 
 from pydantic import ValidationError
 
-from iso15118.shared.exceptions import EXIDecodingError, EXIEncodingError
+from iso15118.shared.exceptions import (
+    EXIDecodingError,
+    EXIEncodingError,
+    V2GMessageValidationError,
+)
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
 from iso15118.shared.iexi_codec import IEXICodec
 from iso15118.shared.messages import BaseModel
@@ -14,8 +18,11 @@ from iso15118.shared.messages.app_protocol import (
     SupportedAppProtocolReq,
     SupportedAppProtocolRes,
 )
+from iso15118.shared.messages.din_spec.body import get_msg_type as get_msg_type_dinspec
 from iso15118.shared.messages.din_spec.msgdef import V2GMessage as V2GMessageDINSPEC
 from iso15118.shared.messages.enums import Namespace
+from iso15118.shared.messages.iso15118_2.body import get_msg_type
+from iso15118.shared.messages.iso15118_2.datatypes import ResponseCode
 from iso15118.shared.messages.iso15118_2.msgdef import V2GMessage as V2GMessageV2
 from iso15118.shared.messages.iso15118_20.ac import (
     ACChargeLoopReq,
@@ -379,10 +386,28 @@ class EXI:
 
             raise EXIDecodingError("Can't identify protocol to use for decoding")
         except ValidationError as exc:
-            raise EXIDecodingError(
-                f"Error parsing the decoded EXI into a Pydantic class: {exc}. "
-                f"\n\nDecoded dict: {decoded_dict}"
+            if namespace == Namespace.ISO_V2_MSG_DEF:
+                msg_name = next(iter(decoded_dict["V2G_Message"]["Body"]))
+                msg_type = get_msg_type(msg_name)
+            elif namespace == Namespace.DIN_MSG_DEF:
+                msg_name = next(iter(decoded_dict["V2G_Message"]["Body"]))
+                msg_type = get_msg_type_dinspec(msg_name)
+            elif namespace.startswith(Namespace.ISO_V20_BASE):
+                msg_type = msg_class
+            elif namespace == Namespace.SAP:
+                if "supportedAppProtocolReq" in decoded_dict:
+                    msg_type = SupportedAppProtocolReq
+                elif "supportedAppProtocolRes" in decoded_dict:
+                    msg_type = SupportedAppProtocolRes
+
+            raise V2GMessageValidationError(
+                f"Validation error: {exc}. \n\nDecoded dict: " f"{decoded_dict}",
+                ResponseCode.FAILED,
+                msg_type,
             ) from exc
+
+        except V2GMessageValidationError as exc:
+            raise exc
         except EXIDecodingError as exc:
             raise EXIDecodingError(
                 f"EXI decoding error: {exc}. \n\nDecoded dict: " f"{decoded_dict}"

--- a/iso15118/shared/messages/iso15118_2/msgdef.py
+++ b/iso15118/shared/messages/iso15118_2/msgdef.py
@@ -12,7 +12,6 @@ Pydantic's Field class is used to be able to create a json schema of each model
 (or class) that matches the definitions in the XSD schema, including the XSD
 element names by using the 'alias' attribute.
 """
-
 from pydantic import Field
 
 from iso15118.shared.messages import BaseModel

--- a/iso15118/shared/messages/iso15118_20/ac.py
+++ b/iso15118/shared/messages/iso15118_20/ac.py
@@ -13,6 +13,7 @@ element names by using the 'alias' attribute.
 
 from pydantic import Field, root_validator
 
+from iso15118.shared.exceptions import V2GMessageValidationError
 from iso15118.shared.messages import BaseModel
 from iso15118.shared.messages.iso15118_20.common_types import (
     ChargeLoopReq,
@@ -22,6 +23,7 @@ from iso15118.shared.messages.iso15118_20.common_types import (
     DynamicChargeLoopReqParams,
     DynamicChargeLoopResParams,
     RationalNumber,
+    ResponseCode,
     ScheduledChargeLoopReqParams,
     ScheduledChargeLoopResParams,
 )
@@ -335,17 +337,24 @@ class ACChargeParameterDiscoveryReq(ChargeParameterDiscoveryReq):
         """
         # pylint: disable=no-self-argument
         # pylint: disable=no-self-use
-        if one_field_must_be_set(
-            [
-                "ac_params",
-                "AC_CPDReqEnergyTransferMode",
-                "bpt_ac_params",
-                "BPT_AC_CPDReqEnergyTransferMode",
-            ],
-            values,
-            True,
-        ):
-            return values
+        try:
+            if one_field_must_be_set(
+                [
+                    "ac_params",
+                    "AC_CPDReqEnergyTransferMode",
+                    "bpt_ac_params",
+                    "BPT_AC_CPDReqEnergyTransferMode",
+                ],
+                values,
+                True,
+            ):
+                return values
+        except ValueError as exc:
+            raise V2GMessageValidationError(
+                str(exc),
+                ResponseCode.FAILED_WRONG_CHARGE_PARAMETER,
+                ChargeParameterDiscoveryReq,
+            )
 
     def __str__(self):
         # The XSD-conform name

--- a/iso15118/shared/messages/iso15118_20/common_types.py
+++ b/iso15118/shared/messages/iso15118_20/common_types.py
@@ -73,7 +73,7 @@ class V2GMessage(BaseModel, ABC):
     """See section 8.3 in ISO 15118-20
     This class model follows the schemas, where the
     V2GMessage type is defined, in the V2G_CI_CommonTypes.xsd schema.
-    This type is the base of all messages and contains the the Header
+    This type is the base of all messages and contains the Header
 
     This is a tiny but quite important difference in respect to ISO 15118-2 payload
     structure, where the header is not included within each Request and Response message

--- a/tests/secc/messages/15118_2_invalid_messages.py
+++ b/tests/secc/messages/15118_2_invalid_messages.py
@@ -1,0 +1,49 @@
+import json
+from dataclasses import dataclass
+
+from iso15118.shared.exceptions import V2GMessageValidationError
+from iso15118.shared.messages.iso15118_2.body import Body, ChargeParameterDiscoveryReq
+from iso15118.shared.messages.iso15118_2.datatypes import ResponseCode
+from iso15118.shared.messages.iso15118_2.msgdef import V2GMessage
+
+
+@dataclass
+class InvalidV2GMessage:
+    msg: str
+    msg_body: Body
+    response_code: ResponseCode
+
+
+invalid_v2g_2_messages = [
+    (
+        InvalidV2GMessage(
+            (
+                # [V2G2-477]
+                # Parameters are not compatible with RequestedEnergyTransferMode
+                '{"V2G_Message":{"Header":{"SessionID":"82DBA3A44ED6E5B9"},"Body":'
+                '{"ChargeParameterDiscoveryReq":{"MaxEntriesSAScheduleTuple":16,'
+                '"RequestedEnergyTransferMode":"AC_three_phase_core",'
+                '"DC_EVChargeParameter":'
+                '{"DepartureTime":0,"DC_EVStatus":{"EVReady":false,"EVErrorCode":'
+                '"NO_ERROR","EVRESSSOC":20},"EVMaximumCurrentLimit":{"Multiplier":'
+                '1,"Unit":"A","Value":8},"EVMaximumPowerLimit":{"Multiplier":3,'
+                '"Unit":"W","Value":29},"EVMaximumVoltageLimit":{"Multiplier":2,'
+                '"Unit":"V","Value":5},"EVEnergyCapacity":{"Multiplier":3,"Unit":'
+                '"Wh","Value":200},"EVEnergyRequest":{"Multiplier":3,"Unit":"Wh",'
+                '"Value":160},"FullSOC":99,"BulkSOC":80}}}}}'
+            ),
+            ChargeParameterDiscoveryReq,
+            ResponseCode.FAILED_WRONG_CHARGE_PARAMETER,
+        )
+    ),
+]
+
+
+def test_invalid_v2g_2_messages():
+    for message in invalid_v2g_2_messages:
+        try:
+            invalid_msg = json.loads(message.msg)
+            V2GMessage.parse_obj(invalid_msg["V2G_Message"])
+        except V2GMessageValidationError as exc:
+            assert exc.message is message.msg_body
+            assert exc.response_code is message.response_code


### PR DESCRIPTION
Fixed [AB#2522](https://dev.azure.com/switch-ev/09ab882d-ca4b-4b5b-b5b8-80603c12e5b2/_workitems/edit/2522)

For the ChargeParameterDiscoveryReq, it is supposed to be return FAILED_WRONG_CHARGE_PARAMETER when a wrong parameter received.