### PR TITLE
get_contactor_state has been added

### DIFF
--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -189,6 +189,10 @@ class SimEVSEController(EVSEControllerInterface):
     A simulated version of an EVSE controller
     """
 
+    def __init__(self):
+        super().__init__()
+        self.contactor = None
+
     @classmethod
     async def create(cls):
         self = SimEVSEController()

--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -977,15 +977,19 @@ class PowerDelivery(StateSECC):
                 # 2nd once the energy transfer is properly interrupted,
                 # the contactor(s) may open
                 contactor_state = (
-                    await self.comm_session.evse_controller.open_contactor()
+                    await self.comm_session.evse_controller.get_contactor_state()
                 )
                 if contactor_state != Contactor.OPENED:
-                    self.stop_state_machine(
-                        "Contactor didnt open",
-                        message,
-                        ResponseCode.FAILED_CONTACTOR_ERROR,
+                    contactor_state = (
+                        await self.comm_session.evse_controller.open_contactor()
                     )
-                    return
+                    if contactor_state != Contactor.OPENED:
+                        self.stop_state_machine(
+                            "Contactor didnt open",
+                            message,
+                            ResponseCode.FAILED_CONTACTOR_ERROR,
+                        )
+                        return
             else:
 
                 # The only ChargeProgress options left are START and
@@ -1020,15 +1024,19 @@ class PowerDelivery(StateSECC):
                 # TODO: We may need to check the CP state is C or D before
                 #  closing the contactors.
                 contactor_state = (
-                    await self.comm_session.evse_controller.close_contactor()
+                    await self.comm_session.evse_controller.get_contactor_state()
                 )
                 if contactor_state != Contactor.CLOSED:
-                    self.stop_state_machine(
-                        "Contactor didnt close",
-                        message,
-                        ResponseCode.FAILED_CONTACTOR_ERROR,
+                    contactor_state = (
+                        await self.comm_session.evse_controller.close_contactor()
                     )
-                    return
+                    if contactor_state != Contactor.CLOSED:
+                        self.stop_state_machine(
+                            "Contactor didnt close",
+                            message,
+                            ResponseCode.FAILED_CONTACTOR_ERROR,
+                        )
+                        return
 
                 # According to section 8.5.6 in ISO 15118-20, the EV enters into HLC-C
                 # (High Level Controlled Charging) once


### PR DESCRIPTION
The contactor state will be checked before the close/open command in order to avoid sending an unnecessary message if it is already closed/opened.