### PR TITLE
Empty string field causes EXI encoding error

### DIFF
--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -647,9 +647,10 @@ class CertificateInstallation(StateSECC):
                     signature,
                 ) = self.generate_certificate_installation_res()
         except Exception as e:
-            logger.error(f"Error building CertificateInstallationRes: {e}")
+            error = f"Error building CertificateInstallationRes: {e}"
+            logger.error(error)
             self.stop_state_machine(
-                str(e),
+                error,
                 message,
                 ResponseCode.FAILED_NO_CERTIFICATE_AVAILABLE,
             )


### PR DESCRIPTION
Summary of change.
FaultMessage field in CertificateInstallationRes can't be empty as this would cause EXI encoding to fail.
In CertificateInstallationRes, the FaultMessage field was getting its value from str(e) where is e is Exception. If this was empty, that would cause EXI encoding to fail. Minor refactor to make sure the field is never empty.