### PR TITLE
Fix: create_certs to generate jks certs for Keysight

### DIFF
--- a/iso15118/shared/pki/configs/moSubCA1Cert.cnf
+++ b/iso15118/shared/pki/configs/moSubCA1Cert.cnf
@@ -3,7 +3,7 @@ prompt 					= no
 distinguished_name		= ca_dn
 
 [ca_dn]
-commonName				= MOSubCA1
+commonName				= PKI-Ext_CRT_MO_SUB1_VALID
 organizationName		= Switch
 countryName				= UK
 domainComponent			= MO

--- a/iso15118/shared/pki/configs/moSubCA2Cert.cnf
+++ b/iso15118/shared/pki/configs/moSubCA2Cert.cnf
@@ -3,7 +3,7 @@ prompt 					= no
 distinguished_name		= ca_dn
 
 [ca_dn]
-commonName				= MOSubCA2
+commonName				= PKI-Ext_CRT_MO_SUB2_VALID
 organizationName		= Switch
 countryName				= UK
 domainComponent			= MO


### PR DESCRIPTION
Updated create_certs.sh to generate certificates for some Keysight setup in .jks format.
Three files are generated:
- truststore.jks
- keystore.jks
- password.txt