### PR TITLE
genchallange check has been added for Authorization

### DIFF
--- a/iso15118/secc/comm_session_handler.py
+++ b/iso15118/secc/comm_session_handler.py
@@ -92,7 +92,7 @@ class SECCCommunicationSession(V2GCommunicationSession):
         self.selected_auth_option: Optional[AuthEnum] = None
         # The generated challenge sent in PaymentDetailsRes. Its copy is expected in
         # AuthorizationReq (applies to Plug & Charge identification mode only)
-        self.gen_challenge: bytes = bytes(0)
+        self.gen_challenge: Optional[bytes] = None
         # In ISO 15118-2, the EVCCID is the MAC address, given as bytes.
         # In ISO 15118-20, the EVCCID is like a VIN number, given as str.
         self.evcc_id: Union[bytes, str, None] = None

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -1021,14 +1021,13 @@ class Authorization(StateSECC):
         # 'FAILED_ChallengeInvalid' if the challenge response contained in the
         # AuthorizationReq message in attribute GenChallenge is not valid versus
         # the provided GenChallenge in PaymentDetailsRes.
-        if authorization_req.gen_challenge:
-            if authorization_req.gen_challenge != self.comm_session.gen_challenge:
-                self.stop_state_machine(
-                    "[V2G2-475] GenChallenge is not the same in PaymentDetailsRes",
-                    message,
-                    ResponseCode.FAILED_CHALLENGE_INVALID,
-                )
-                return
+        if authorization_req.gen_challenge != self.comm_session.gen_challenge:
+            self.stop_state_machine(
+                "[V2G2-475] GenChallenge is not the same in PaymentDetailsRes",
+                message,
+                ResponseCode.FAILED_CHALLENGE_INVALID,
+            )
+            return
 
         if self.comm_session.selected_auth_option == AuthEnum.PNC_V2:
             if not self.comm_session.contract_cert_chain:

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -914,10 +914,10 @@ class PaymentDetails(StateSECC):
                 AuthorizationStatus.ACCEPTED,
                 AuthorizationStatus.ONGOING,
             ]:
-
+                self.comm_session.gen_challenge = get_random_bytes(16)
                 payment_details_res = PaymentDetailsRes(
                     response_code=ResponseCode.OK,
-                    gen_challenge=get_random_bytes(16),
+                    gen_challenge=self.comm_session.gen_challenge,
                     evse_timestamp=time.time(),
                 )
 
@@ -1016,6 +1016,19 @@ class Authorization(StateSECC):
             return
 
         authorization_req: AuthorizationReq = msg.body.authorization_req
+
+        # [V2G2-475] The message 'AuthorizationRes' shall contain the ResponseCode
+        # 'FAILED_ChallengeInvalid' if the challenge response contained in the
+        # AuthorizationReq message in attribute GenChallenge is not valid versus
+        # the provided GenChallenge in PaymentDetailsRes.
+        if authorization_req.gen_challenge:
+            if authorization_req.gen_challenge != self.comm_session.gen_challenge:
+                self.stop_state_machine(
+                    "[V2G2-475] GenChallenge is not the same in PaymentDetailsRes",
+                    message,
+                    ResponseCode.FAILED_CHALLENGE_INVALID,
+                )
+                return
 
         if self.comm_session.selected_auth_option == AuthEnum.PNC_V2:
             if not self.comm_session.contract_cert_chain:

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -26,6 +26,8 @@ from iso15118.shared.messages.enums import (
 )
 from iso15118.shared.messages.iso15118_2.body import ResponseCode
 from iso15118.shared.messages.iso15118_2.datatypes import ACEVSEStatus, CertificateChain
+from iso15118.shared.messages.iso15118_2.datatypes import CertificateChain
+from iso15118.shared.security import get_random_bytes
 from tests.secc.states.test_messages import (
     get_charge_parameter_discovery_req_message_departure_time_one_hour,
     get_charge_parameter_discovery_req_message_no_departure_time,
@@ -201,6 +203,40 @@ class TestV2GSessionScenarios:
             authorization.message.body.authorization_res.evse_processing
             == expected_evse_processing
         )
+
+    async def test_authorization_req_gen_challenge_invalid(self):
+        self.comm_session.writer = Mock()
+        self.comm_session.writer.get_extra_info = Mock()
+
+        self.comm_session.gen_challenge = get_random_bytes(16)
+        id = "aReq"
+        gen_challenge = get_random_bytes(16)
+        authorization = Authorization(self.comm_session)
+
+        await authorization.process_message(
+            message=get_dummy_v2g_message_authorization_req(id, gen_challenge)
+        )
+        assert authorization.next_state == Terminate
+        assert (
+            authorization.message.body.authorization_res.response_code
+            == ResponseCode.FAILED_CHALLENGE_INVALID
+        )
+
+    async def test_authorization_req_gen_challenge_valid(self):
+        self.comm_session.writer = Mock()
+        self.comm_session.writer.get_extra_info = Mock()
+        self.comm_session.selected_auth_option = AuthEnum.PNC_V2
+        self.comm_session.gen_challenge = get_random_bytes(16)
+        id = "aReq"
+        gen_challenge = self.comm_session.gen_challenge
+        self.comm_session.contract_cert_chain = Mock()
+        self.comm_session.emaid = "dummy"
+        authorization = Authorization(self.comm_session)
+        authorization.signature_verified_once = True
+        await authorization.process_message(
+            message=get_dummy_v2g_message_authorization_req(id, gen_challenge)
+        )
+        assert authorization.next_state == ChargeParameterDiscovery
 
     async def test_charge_parameter_discovery_res_v2g2_303(self):
         # V2G2-303 : Sum of individual time intervals shall match the period of time

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -26,7 +26,6 @@ from iso15118.shared.messages.enums import (
 )
 from iso15118.shared.messages.iso15118_2.body import ResponseCode
 from iso15118.shared.messages.iso15118_2.datatypes import ACEVSEStatus, CertificateChain
-from iso15118.shared.messages.iso15118_2.datatypes import CertificateChain
 from iso15118.shared.security import get_random_bytes
 from tests.secc.states.test_messages import (
     get_charge_parameter_discovery_req_message_departure_time_one_hour,

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -188,6 +188,7 @@ class TestV2GSessionScenarios:
         #      `get_dummy_v2g_message_authorization_req`
         self.comm_session.contract_cert_chain = Mock()
         self.comm_session.emaid = "dummy"
+        self.comm_session.gen_challenge = None
         authorization = Authorization(self.comm_session)
         authorization.signature_verified_once = True
         await authorization.process_message(

--- a/tests/secc/states/test_messages.py
+++ b/tests/secc/states/test_messages.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from iso15118.shared.messages.datatypes import (
     PVEAmount,
@@ -118,11 +118,15 @@ def get_dummy_v2g_message_session_stop_req():
     )
 
 
-def get_dummy_v2g_message_authorization_req():
+def get_dummy_v2g_message_authorization_req(
+    id: Optional[str] = None, gen_challenge: Optional[bytes] = None
+):
     # The AuthorizationReq is empty, unless it is following a PaymentDetailsRes
     # message, in which case it must send back the generated challenge.
-    authorization_req = AuthorizationReq()
-
+    if gen_challenge:
+        authorization_req = AuthorizationReq(id=id, gen_challenge=gen_challenge)
+    else:
+        authorization_req = AuthorizationReq()
     return V2GMessage(
         header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(authorization_req=authorization_req),


### PR DESCRIPTION
 fix [AB#2850](https://dev.azure.com/switch-ev/09ab882d-ca4b-4b5b-b5b8-80603c12e5b2/_workitems/edit/2850)

According to spec 15118-2  [V2G2-475], the GenChallenge in AuthorizationReq should be the same in PaymentDetailsRes. Otherwise, we need to return FAILED_ChallengeInvalid.

[V2G2-475] The message 'AuthorizationRes' shall contain the ResponseCode
'FAILED_ChallengeInvalid' if the challenge response contained in the
 AuthorizationReq message in attribute GenChallenge is not valid versus
the provided GenChallenge in PaymentDetailsRes.