### PR TITLE
feat/service_status/ab#2950

### DIFF
--- a/iso15118/secc/comm_session_handler.py
+++ b/iso15118/secc/comm_session_handler.py
@@ -16,10 +16,7 @@ import socket
 from asyncio.streams import StreamReader, StreamWriter
 from typing import Dict, List, Optional, Tuple, Union
 
-from iso15118.secc.controller.interface import (
-    EVSEControllerInterface,
-    EVSEServiceStatus,
-)
+from iso15118.secc.controller.interface import EVSEControllerInterface, ServiceStatus
 from iso15118.secc.failed_responses import (
     init_failed_responses_din_spec_70121,
     init_failed_responses_iso_v2,
@@ -195,21 +192,24 @@ class CommunicationSessionHandler:
         """
 
         self.udp_server = UDPServer(self._rcv_queue, self.config.iface)
-        self.status_event_list.append(self.udp_server.ready_event)
+        udp_ready_event: asyncio.Event = asyncio.Event()
+        self.status_event_list.append(udp_ready_event)
 
         self.tcp_server = TCPServer(self._rcv_queue, self.config.iface)
-        self.status_event_list.append(self.tcp_server.tls_ready_event)
+        tls_ready_event: asyncio.Event = asyncio.Event()
+        self.status_event_list.append(tls_ready_event)
 
         self.list_of_tasks = [
             self.get_from_rcv_queue(self._rcv_queue),
-            self.udp_server.start(),
-            self.tcp_server.start_tls(),
+            self.udp_server.start(udp_ready_event),
+            self.tcp_server.start_tls(tls_ready_event),
             self.check_status_task(),
         ]
 
         if not self.config.enforce_tls:
-            self.list_of_tasks.append(self.tcp_server.start_no_tls())
-            self.status_event_list.append(self.tcp_server.tcp_ready_event)
+            tcp_ready_event: asyncio.Event = asyncio.Event()
+            self.status_event_list.append(tcp_ready_event)
+            self.list_of_tasks.append(self.tcp_server.start_no_tls(tcp_ready_event))
 
         logger.info("Communication session handler started")
 
@@ -226,15 +226,15 @@ class CommunicationSessionHandler:
     async def check_ready_status(self) -> None:
         # Wait until all flags are set
         while self.check_events() is False:
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.01)
 
     async def check_status_task(self) -> None:
         try:
             await asyncio.wait_for(self.check_ready_status(), timeout=10)
-            await self.evse_controller.set_status(EVSEServiceStatus.READY)
+            await self.evse_controller.set_status(ServiceStatus.READY)
         except asyncio.TimeoutError:
             logger.error("Timeout: Servers failed to startup")
-            await self.evse_controller.set_status(EVSEServiceStatus.ERROR)
+            await self.evse_controller.set_status(ServiceStatus.ERROR)
 
     async def get_from_rcv_queue(self, queue: asyncio.Queue):
         """

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -4,6 +4,7 @@ This module contains the abstract class for an SECC to retrieve data from the EV
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Dict, List, Optional, Union
 
 from iso15118.shared.messages.datatypes import (
@@ -72,6 +73,14 @@ class EVDataContext:
     soc: Optional[int] = None  # 0-100
 
 
+class EVSEServiceStatus(str, Enum):
+    READY = "ready"
+    STARTING = "starting"
+    STOPPING = "stopping"
+    ERROR = "error"
+    BUSY = "busy"
+
+
 @dataclass
 class EVChargeParamsLimits:
     ev_max_voltage: Optional[Union[PVEVMaxVoltageLimit, PVEVMaxVoltage]] = None
@@ -90,6 +99,13 @@ class EVSEControllerInterface(ABC):
     # ============================================================================
     # |             COMMON FUNCTIONS (FOR ALL ENERGY TRANSFER MODES)             |
     # ============================================================================
+
+    @abstractmethod
+    async def set_status(self, status: EVSEServiceStatus) -> None:
+        """
+        Sets the new status for the EVSE Controller
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def get_evse_id(self, protocol: Protocol) -> str:

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -73,7 +73,7 @@ class EVDataContext:
     soc: Optional[int] = None  # 0-100
 
 
-class EVSEServiceStatus(str, Enum):
+class ServiceStatus(str, Enum):
     READY = "ready"
     STARTING = "starting"
     STOPPING = "stopping"
@@ -101,7 +101,7 @@ class EVSEControllerInterface(ABC):
     # ============================================================================
 
     @abstractmethod
-    async def set_status(self, status: EVSEServiceStatus) -> None:
+    async def set_status(self, status: ServiceStatus) -> None:
         """
         Sets the new status for the EVSE Controller
         """

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -15,6 +15,7 @@ from iso15118.secc.controller.interface import (
     EVChargeParamsLimits,
     EVDataContext,
     EVSEControllerInterface,
+    EVSEServiceStatus,
 )
 from iso15118.shared.exceptions import EncryptionError, PrivateKeyReadError
 from iso15118.shared.exi_codec import EXI
@@ -195,6 +196,8 @@ class SimEVSEController(EVSEControllerInterface):
     # ============================================================================
     # |             COMMON FUNCTIONS (FOR ALL ENERGY TRANSFER MODES)             |
     # ============================================================================
+    async def set_status(self, status: EVSEServiceStatus) -> None:
+        logger.debug(f"New Status: {status}")
 
     async def get_evse_id(self, protocol: Protocol) -> str:
         if protocol == Protocol.DIN_SPEC_70121:

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -15,7 +15,7 @@ from iso15118.secc.controller.interface import (
     EVChargeParamsLimits,
     EVDataContext,
     EVSEControllerInterface,
-    EVSEServiceStatus,
+    ServiceStatus,
 )
 from iso15118.shared.exceptions import EncryptionError, PrivateKeyReadError
 from iso15118.shared.exi_codec import EXI
@@ -196,7 +196,7 @@ class SimEVSEController(EVSEControllerInterface):
     # ============================================================================
     # |             COMMON FUNCTIONS (FOR ALL ENERGY TRANSFER MODES)             |
     # ============================================================================
-    async def set_status(self, status: EVSEServiceStatus) -> None:
+    async def set_status(self, status: ServiceStatus) -> None:
         logger.debug(f"New Status: {status}")
 
     async def get_evse_id(self, protocol: Protocol) -> str:

--- a/iso15118/secc/main.py
+++ b/iso15118/secc/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from iso15118.secc import SECCHandler
-from iso15118.secc.controller.interface import EVSEServiceStatus
+from iso15118.secc.controller.interface import ServiceStatus
 from iso15118.secc.controller.simulator import SimEVSEController
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
 
@@ -15,7 +15,7 @@ async def main():
     the SECC (Supply Equipment Communication Controller)
     """
     sim_evse_controller = await SimEVSEController.create()
-    await sim_evse_controller.set_status(EVSEServiceStatus.STARTING)
+    await sim_evse_controller.set_status(ServiceStatus.STARTING)
     await SECCHandler(
         exi_codec=ExificientEXICodec(), evse_controller=sim_evse_controller
     ).start()

--- a/iso15118/secc/main.py
+++ b/iso15118/secc/main.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from iso15118.secc import SECCHandler
+from iso15118.secc.controller.interface import EVSEServiceStatus
 from iso15118.secc.controller.simulator import SimEVSEController
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
 
@@ -14,6 +15,7 @@ async def main():
     the SECC (Supply Equipment Communication Controller)
     """
     sim_evse_controller = await SimEVSEController.create()
+    await sim_evse_controller.set_status(EVSEServiceStatus.STARTING)
     await SECCHandler(
         exi_codec=ExificientEXICodec(), evse_controller=sim_evse_controller
     ).start()

--- a/iso15118/secc/transport/tcp_server.py
+++ b/iso15118/secc/transport/tcp_server.py
@@ -27,26 +27,24 @@ class TCPServer(asyncio.Protocol):
         self.port_no_tls = get_tcp_port()
         self.port_tls = get_tcp_port()
         self.iface = iface
-        self.tls_ready_event: asyncio.Event = asyncio.Event()
-        self.tcp_ready_event: asyncio.Event = asyncio.Event()
 
         # Making sure the TCP and TLS port are definitely different
         while self.port_no_tls == self.port_tls:
             self.port_tls = get_tcp_port()
 
-    async def start_tls(self):
+    async def start_tls(self, ready_event: asyncio.Event):
         """
         Uses the `server_factory` to start a TLS based server
         """
-        await self.server_factory(tls=True)
+        await self.server_factory(ready_event, tls=True)
 
-    async def start_no_tls(self):
+    async def start_no_tls(self, ready_event: asyncio.Event):
         """
         Uses the `server_factory` to start a regular TCO based server (No TLS)
         """
-        await self.server_factory(tls=False)
+        await self.server_factory(ready_event, tls=False)
 
-    async def server_factory(self, tls: bool) -> None:
+    async def server_factory(self, ready_event: asyncio.Event, tls: bool) -> None:
         """
         Factory method to spawn a new server.
 
@@ -114,10 +112,7 @@ class TCPServer(asyncio.Protocol):
             f"port {port}"
         )
 
-        if tls:
-            self.tls_ready_event.set()
-        else:
-            self.tcp_ready_event.set()
+        ready_event.set()
 
         try:
             # Shield the task so we can handle the cancellation

--- a/iso15118/secc/transport/tcp_server.py
+++ b/iso15118/secc/transport/tcp_server.py
@@ -27,6 +27,8 @@ class TCPServer(asyncio.Protocol):
         self.port_no_tls = get_tcp_port()
         self.port_tls = get_tcp_port()
         self.iface = iface
+        self.tls_ready_event: asyncio.Event = asyncio.Event()
+        self.tcp_ready_event: asyncio.Event = asyncio.Event()
 
         # Making sure the TCP and TLS port are definitely different
         while self.port_no_tls == self.port_tls:
@@ -111,6 +113,11 @@ class TCPServer(asyncio.Protocol):
             f"address {self.ipv6_address_host}%{self.iface} and "
             f"port {port}"
         )
+
+        if tls:
+            self.tls_ready_event.set()
+        else:
+            self.tcp_ready_event.set()
 
         try:
             # Shield the task so we can handle the cancellation

--- a/iso15118/secc/transport/udp_server.py
+++ b/iso15118/secc/transport/udp_server.py
@@ -36,7 +36,6 @@ class UDPServer(asyncio.DatagramProtocol):
     def __init__(self, session_handler_queue: asyncio.Queue, iface: str):
         self.started: bool = False
         self.iface = iface
-        self.ready_event: asyncio.Event = asyncio.Event()
         self._session_handler_queue: asyncio.Queue = session_handler_queue
         self._rcv_queue: asyncio.Queue = asyncio.Queue()
         self._transport: Optional[DatagramTransport] = None
@@ -83,7 +82,7 @@ class UDPServer(asyncio.DatagramProtocol):
 
         return sock
 
-    async def start(self):
+    async def start(self, ready_event: asyncio.Event):
         """UDP server tasks to start"""
         # Get a reference to the event loop as we plan to use a low-level API
         # (see loop.create_datagram_endpoint())
@@ -100,7 +99,7 @@ class UDPServer(asyncio.DatagramProtocol):
             f"{SDP_MULTICAST_GROUP}%{self.iface} "
             f"and port {SDP_SERVER_PORT}"
         )
-        self.ready_event.set()
+        ready_event.set()
         tasks = [self.rcv_task()]
         await wait_for_tasks(tasks)
 

--- a/iso15118/secc/transport/udp_server.py
+++ b/iso15118/secc/transport/udp_server.py
@@ -36,6 +36,7 @@ class UDPServer(asyncio.DatagramProtocol):
     def __init__(self, session_handler_queue: asyncio.Queue, iface: str):
         self.started: bool = False
         self.iface = iface
+        self.ready_event: asyncio.Event = asyncio.Event()
         self._session_handler_queue: asyncio.Queue = session_handler_queue
         self._rcv_queue: asyncio.Queue = asyncio.Queue()
         self._transport: Optional[DatagramTransport] = None
@@ -99,6 +100,7 @@ class UDPServer(asyncio.DatagramProtocol):
             f"{SDP_MULTICAST_GROUP}%{self.iface} "
             f"and port {SDP_SERVER_PORT}"
         )
+        self.ready_event.set()
         tasks = [self.rcv_task()]
         await wait_for_tasks(tasks)
 


### PR DESCRIPTION
This PR allows setting and logging service status based on the servers' statuses:
  
- The condition for the service to be ready is that all servers are up and running. This condition is checked every 100 mS.
- There is a 10-second timeout to notify that not all servers have been started.