### PR TITLE
Fix/genchallange invalid

### DIFF
--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -207,7 +207,8 @@ class TestV2GSessionScenarios:
     async def test_authorization_req_gen_challenge_invalid(self):
         self.comm_session.writer = Mock()
         self.comm_session.writer.get_extra_info = Mock()
-
+        self.comm_session.selected_auth_option = AuthEnum.PNC_V2
+        self.comm_session.contract_cert_chain = Mock()
         self.comm_session.gen_challenge = get_random_bytes(16)
         id = "aReq"
         gen_challenge = get_random_bytes(16)


### PR DESCRIPTION
According to spec, GenChallenge is only sent on the first AuthorizationReq message by EV.

[V2G2-684] After receiving the AuthorizationRes, the EVCC shall send an empty AuthorizationReq while V2G_EVCC_Sequence_Timer is smaller than V2G_EVCC_Sequence_Performance_Time as long as the parameter EVSEProcessing is equal to 'Ongoing'.
NOTE 2 The EV only sends a AuthorizationReq message containing a Signature, Id and GenChallenge included as the first AuthorizationReq message. Consecutive messages that are only required when a AuthorizationRes message was received with EVSEProcessing set to Ongoing are sent without this information.