### PR TITLE
UDP listener now bound to specific interface

### DIFF
--- a/iso15118/secc/__init__.py
+++ b/iso15118/secc/__init__.py
@@ -19,11 +19,11 @@ class SECCHandler(CommunicationSessionHandler):
         evse_controller: EVSEControllerInterface,
         env_path: Optional[str] = None,
     ):
-        config = Config()
-        config.load_envs(env_path)
+        self.config = Config()
+        self.config.load_envs(env_path)
         CommunicationSessionHandler.__init__(
             self,
-            config,
+            self.config,
             exi_codec,
             evse_controller,
         )
@@ -31,7 +31,7 @@ class SECCHandler(CommunicationSessionHandler):
     async def start(self):
         try:
             logger.info(f"Starting 15118 version: {__version__}")
-            await self.start_session_handler()
+            await self.start_session_handler(self.config.iface)
         except Exception as exc:
             logger.error(f"SECC terminated: {exc}")
             # Re-raise so the process ends with a non-zero exit code and the

--- a/iso15118/secc/comm_session_handler.py
+++ b/iso15118/secc/comm_session_handler.py
@@ -183,7 +183,7 @@ class CommunicationSessionHandler:
         # associated ayncio.Task object (so we can cancel the task when needed)
         self.comm_sessions: Dict[str, (SECCCommunicationSession, asyncio.Task)] = {}
 
-    async def start_session_handler(self):
+    async def start_session_handler(self, iface: str):
         """
         This method is necessary, because python does not allow
         async def __init__.
@@ -191,11 +191,11 @@ class CommunicationSessionHandler:
         constructor.
         """
 
-        self.udp_server = UDPServer(self._rcv_queue, self.config.iface)
+        self.udp_server = UDPServer(self._rcv_queue, iface)
         udp_ready_event: asyncio.Event = asyncio.Event()
         self.status_event_list.append(udp_ready_event)
 
-        self.tcp_server = TCPServer(self._rcv_queue, self.config.iface)
+        self.tcp_server = TCPServer(self._rcv_queue, iface)
         tls_ready_event: asyncio.Event = asyncio.Event()
         self.status_event_list.append(tls_ready_event)
 

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -33,6 +33,7 @@ from iso15118.shared.messages.enums import (
     CpState,
     EnergyTransferModeEnum,
     Protocol,
+    SessionStopAction,
 )
 from iso15118.shared.messages.iso15118_2.datatypes import (
     ACEVSEChargeParameter,
@@ -695,6 +696,17 @@ class EVSEControllerInterface(ABC):
         Returns:
          CertificateInstallationRes EXI stream in base64 encoded form.
 
+        Relevant for:
+        - ISO 15118-20 and ISO 15118-2
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def session_stop(self, action: SessionStopAction) -> None:
+        """
+        Called when EV requires termination or pausing of the charging session.
+        Args:
+            action : SessionStopAction
         Relevant for:
         - ISO 15118-20 and ISO 15118-2
         """

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -58,6 +58,7 @@ from iso15118.shared.messages.enums import (
     Namespace,
     PriceAlgorithm,
     Protocol,
+    SessionStopAction,
     UnitSymbol,
 )
 from iso15118.shared.messages.iso15118_2.body import Body, CertificateInstallationRes
@@ -910,3 +911,9 @@ class SimEVSEController(EVSEControllerInterface):
         ).decode("utf-8")
 
         return base64_encode_cert_install_res
+
+    async def session_stop(self, action: SessionStopAction) -> None:
+        """
+        Overrides EVSEControllerInterface.session_stop().
+        """
+        pass

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -84,6 +84,7 @@ from iso15118.shared.messages.iso15118_2.datatypes import (
     CertificateChain,
     ChargeProgress,
     ChargeService,
+    ChargingSession,
     DHPublicKey,
     EncryptedPrivateKey,
     EnergyTransferModeList,
@@ -123,7 +124,7 @@ from iso15118.shared.security import (
     verify_certs,
     verify_signature,
 )
-from iso15118.shared.states import Base64, State, Terminate
+from iso15118.shared.states import Base64, Pause, State, Terminate
 
 logger = logging.getLogger(__name__)
 
@@ -1762,9 +1763,12 @@ class SessionStop(StateSECC):
             f"EV Requested to {session_status} the communication session",
             self.comm_session.writer.get_extra_info("peername"),
         )
-
+        if msg.body.session_stop_req.charging_session == ChargingSession.PAUSE:
+            next_state = Pause
+        else:
+            next_state = Terminate
         self.create_next_message(
-            Terminate,
+            next_state,
             SessionStopRes(response_code=ResponseCode.OK),
             Timeouts.V2G_SECC_SEQUENCE_TIMEOUT,
             Namespace.ISO_V2_MSG_DEF,

--- a/iso15118/secc/transport/udp_server.py
+++ b/iso15118/secc/transport/udp_server.py
@@ -6,7 +6,11 @@ from asyncio import DatagramTransport
 from typing import Optional, Tuple
 
 from iso15118.shared.messages.v2gtp import V2GTPMessage
-from iso15118.shared.network import SDP_MULTICAST_GROUP, SDP_SERVER_PORT
+from iso15118.shared.network import (
+    SDP_MULTICAST_GROUP,
+    SDP_SERVER_PORT,
+    get_link_local_full_addr,
+)
 from iso15118.shared.notifications import (
     ReceiveTimeoutNotification,
     UDPPacketNotification,
@@ -41,7 +45,7 @@ class UDPServer(asyncio.DatagramProtocol):
         self._transport: Optional[DatagramTransport] = None
 
     @staticmethod
-    def _create_socket(iface: str) -> "socket":
+    async def _create_socket(iface: str) -> "socket":
         """
         This method is necessary because Python does not allow
         async def __init__.
@@ -58,7 +62,8 @@ class UDPServer(asyncio.DatagramProtocol):
 
         # Bind the socket to the predefined port for receiving
         # UDP packets (SDP requests)
-        sock.bind(("", SDP_SERVER_PORT))
+        full_ipv6_address = await get_link_local_full_addr(SDP_SERVER_PORT, iface)
+        sock.bind(full_ipv6_address)
 
         # After the regular socket is created and bound to a port, it can be
         # added to the multicast group by using setsockopt() to set the
@@ -90,7 +95,7 @@ class UDPServer(asyncio.DatagramProtocol):
         # One protocol instance will be created to serve all client requests
         self._transport, _ = await loop.create_datagram_endpoint(
             lambda: self,
-            sock=self._create_socket(self.iface),
+            sock=await self._create_socket(self.iface),
             reuse_address=True,
         )
 

--- a/iso15118/shared/messages/enums.py
+++ b/iso15118/shared/messages/enums.py
@@ -436,3 +436,8 @@ class CpState(str, Enum):
     E = "E"
     F = "F"
     UNKNOWN = "UNKNOWN"
+
+
+class SessionStopAction(str, Enum):
+    TERMINATE = "terminate"
+    PAUSE = "pause"

--- a/tests/secc/states/test_iso15118_2_states.py
+++ b/tests/secc/states/test_iso15118_2_states.py
@@ -25,7 +25,7 @@ from iso15118.shared.messages.enums import (
     CpState,
     EVSEProcessing,
 )
-from iso15118.shared.messages.iso15118_2.body import ResponseCode, SessionStopReq
+from iso15118.shared.messages.iso15118_2.body import ResponseCode
 from iso15118.shared.messages.iso15118_2.datatypes import (
     ACEVSEStatus,
     CertificateChain,

--- a/tests/secc/states/test_messages.py
+++ b/tests/secc/states/test_messages.py
@@ -231,3 +231,12 @@ def get_dummy_charging_status_req() -> V2GMessage:
         header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(charging_status_req=charging_status_req),
     )
+
+
+def get_dummy_v2g_session_stop_req(charging_session: ChargingSession) -> V2GMessage:
+    session_stop_req = SessionStopReq(charging_session=charging_session)
+
+    return V2GMessage(
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
+        body=Body(session_stop_req=session_stop_req),
+    )


### PR DESCRIPTION
Summary of the change:
- UDP server is now bound to the specific interface as set in the .env file
- The interface to bind to could be passed in as an argument via start_session_handler(). This removes reliance on env setting in josev_pro.