### PR TITLE
Update udp socket to bind to specific interface

### DIFF
--- a/iso15118/secc/__init__.py
+++ b/iso15118/secc/__init__.py
@@ -19,11 +19,11 @@ class SECCHandler(CommunicationSessionHandler):
         evse_controller: EVSEControllerInterface,
         env_path: Optional[str] = None,
     ):
-        config = Config()
-        config.load_envs(env_path)
+        self.config = Config()
+        self.config.load_envs(env_path)
         CommunicationSessionHandler.__init__(
             self,
-            config,
+            self.config,
             exi_codec,
             evse_controller,
         )
@@ -31,7 +31,7 @@ class SECCHandler(CommunicationSessionHandler):
     async def start(self):
         try:
             logger.info(f"Starting 15118 version: {__version__}")
-            await self.start_session_handler()
+            await self.start_session_handler(self.config.iface)
         except Exception as exc:
             logger.error(f"SECC terminated: {exc}")
             # Re-raise so the process ends with a non-zero exit code and the

--- a/iso15118/secc/__init__.py
+++ b/iso15118/secc/__init__.py
@@ -17,21 +17,19 @@ class SECCHandler(CommunicationSessionHandler):
         self,
         exi_codec: IEXICodec,
         evse_controller: EVSEControllerInterface,
-        env_path: Optional[str] = None,
+        config: Config,
     ):
-        self.config = Config()
-        self.config.load_envs(env_path)
         CommunicationSessionHandler.__init__(
             self,
-            self.config,
+            config,
             exi_codec,
             evse_controller,
         )
 
-    async def start(self):
+    async def start(self, iface: str):
         try:
             logger.info(f"Starting 15118 version: {__version__}")
-            await self.start_session_handler(self.config.iface)
+            await self.start_session_handler(iface)
         except Exception as exc:
             logger.error(f"SECC terminated: {exc}")
             # Re-raise so the process ends with a non-zero exit code and the

--- a/iso15118/secc/comm_session_handler.py
+++ b/iso15118/secc/comm_session_handler.py
@@ -183,7 +183,7 @@ class CommunicationSessionHandler:
         # associated ayncio.Task object (so we can cancel the task when needed)
         self.comm_sessions: Dict[str, (SECCCommunicationSession, asyncio.Task)] = {}
 
-    async def start_session_handler(self):
+    async def start_session_handler(self, iface: str):
         """
         This method is necessary, because python does not allow
         async def __init__.
@@ -191,11 +191,11 @@ class CommunicationSessionHandler:
         constructor.
         """
 
-        self.udp_server = UDPServer(self._rcv_queue, self.config.iface)
+        self.udp_server = UDPServer(self._rcv_queue, iface)
         udp_ready_event: asyncio.Event = asyncio.Event()
         self.status_event_list.append(udp_ready_event)
 
-        self.tcp_server = TCPServer(self._rcv_queue, self.config.iface)
+        self.tcp_server = TCPServer(self._rcv_queue, iface)
         tls_ready_event: asyncio.Event = asyncio.Event()
         self.status_event_list.append(tls_ready_event)
 

--- a/iso15118/secc/main.py
+++ b/iso15118/secc/main.py
@@ -4,6 +4,7 @@ import logging
 from iso15118.secc import SECCHandler
 from iso15118.secc.controller.interface import ServiceStatus
 from iso15118.secc.controller.simulator import SimEVSEController
+from iso15118.secc.secc_settings import Config
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
 
 logger = logging.getLogger(__name__)
@@ -14,11 +15,16 @@ async def main():
     Entrypoint function that starts the ISO 15118 code running on
     the SECC (Supply Equipment Communication Controller)
     """
+    config = Config()
+    config.load_envs()
+
     sim_evse_controller = await SimEVSEController.create()
     await sim_evse_controller.set_status(ServiceStatus.STARTING)
     await SECCHandler(
-        exi_codec=ExificientEXICodec(), evse_controller=sim_evse_controller
-    ).start()
+        exi_codec=ExificientEXICodec(),
+        evse_controller=sim_evse_controller,
+        config=config,
+    ).start(config.iface)
 
 
 def run():

--- a/iso15118/secc/transport/udp_server.py
+++ b/iso15118/secc/transport/udp_server.py
@@ -6,8 +6,11 @@ from asyncio import DatagramTransport
 from typing import Optional, Tuple
 
 from iso15118.shared.messages.v2gtp import V2GTPMessage
-from iso15118.shared.network import SDP_MULTICAST_GROUP, SDP_SERVER_PORT, \
-    get_link_local_full_addr
+from iso15118.shared.network import (
+    SDP_MULTICAST_GROUP,
+    SDP_SERVER_PORT,
+    get_link_local_full_addr,
+)
 from iso15118.shared.notifications import (
     ReceiveTimeoutNotification,
     UDPPacketNotification,

--- a/iso15118/secc/transport/udp_server.py
+++ b/iso15118/secc/transport/udp_server.py
@@ -6,7 +6,8 @@ from asyncio import DatagramTransport
 from typing import Optional, Tuple
 
 from iso15118.shared.messages.v2gtp import V2GTPMessage
-from iso15118.shared.network import SDP_MULTICAST_GROUP, SDP_SERVER_PORT
+from iso15118.shared.network import SDP_MULTICAST_GROUP, SDP_SERVER_PORT, \
+    get_link_local_full_addr
 from iso15118.shared.notifications import (
     ReceiveTimeoutNotification,
     UDPPacketNotification,
@@ -41,7 +42,7 @@ class UDPServer(asyncio.DatagramProtocol):
         self._transport: Optional[DatagramTransport] = None
 
     @staticmethod
-    def _create_socket(iface: str) -> "socket":
+    async def _create_socket(iface: str) -> "socket":
         """
         This method is necessary because Python does not allow
         async def __init__.
@@ -58,7 +59,8 @@ class UDPServer(asyncio.DatagramProtocol):
 
         # Bind the socket to the predefined port for receiving
         # UDP packets (SDP requests)
-        sock.bind(("", SDP_SERVER_PORT))
+        full_ipv6_address = await get_link_local_full_addr(SDP_SERVER_PORT, iface)
+        sock.bind(full_ipv6_address)
 
         # After the regular socket is created and bound to a port, it can be
         # added to the multicast group by using setsockopt() to set the
@@ -90,7 +92,7 @@ class UDPServer(asyncio.DatagramProtocol):
         # One protocol instance will be created to serve all client requests
         self._transport, _ = await loop.create_datagram_endpoint(
             lambda: self,
-            sock=self._create_socket(self.iface),
+            sock=await self._create_socket(self.iface),
             reuse_address=True,
         )
 


### PR DESCRIPTION
Summary of changes:
- UDP socket now binds to the specific interface as defined in .env
- The interface to be used could be passed via start_secc_handler(). This helps remove reliance on env file when required. 