### PR TITLE
Bugfix - Binding the port to the socket does not work (Linux)

### DIFF
--- a/iso15118/secc/transport/udp_server.py
+++ b/iso15118/secc/transport/udp_server.py
@@ -77,7 +77,7 @@ class UDPServer(asyncio.DatagramProtocol):
                 socket.SO_BINDTODEVICE,
                 (iface + "\0").encode("ascii"),
             )
-            sock.bind("", SDP_SERVER_PORT)
+            sock.bind(("", SDP_SERVER_PORT))
 
         # After the regular socket is created and bound to a port, it can be
         # added to the multicast group by using setsockopt() to set the


### PR DESCRIPTION
Fixing a bug that prevented the port from being bound to the socket under Linux

Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>