### PR TITLE
Update datatypes.py - fixed range for ChargingProfileEntryMaxPower

### DIFF
--- a/iso15118/shared/messages/din_spec/datatypes.py
+++ b/iso15118/shared/messages/din_spec/datatypes.py
@@ -290,7 +290,7 @@ class ProfileEntryDetails(BaseModel):
     """See section 9.5.2.7 in DIN SPEC 70121"""
 
     start: int = Field(..., alias="ChargingProfileEntryStart")
-    max_power: int = Field(..., ge=1, le=255, alias="ChargingProfileMaxPower")
+    max_power: int = Field(..., ge=0, le=32767, alias="ChargingProfileEntryMaxPower")
 
 
 class ChargingProfile(BaseModel):


### PR DESCRIPTION
This is fix for the issue mentioned here: 
https://github.com/SwitchEV/iso15118/issues/89
Error seen:
```
pydantic.error_wrappers.ValidationError: 1 validation error for ProfileEntryDetails
ChargingProfileMaxPower
ensure this value is less than or equal to 255 (type=value_error.number.not_le; limit_value=255)
```
The range specified for ChargingProfileMaxPower seems to be incorrect. The field type is PMaxType which is xs:short. This PR updates the range to match that of p_max in PMaxScheduleEntry.
```
<xs:complexType name="ProfileEntryType">
  <xs:sequence>
    <xs:element name="ChargingProfileEntryStart" type="xs:unsignedInt"/>
    <xs:element name="ChargingProfileEntryMaxPower" type="PMaxType"/>
  </xs:sequence>
</xs:complexType>

<xs:simpleType name="PMaxType">
  <xs:restriction base="xs:short"/>
</xs:simpleType>
```