### PR TITLE
Fix for UDP server failing to start on Linux VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ The primary dependencies to install the project are the following:
 > - Linux
 >
 >   - MacOS is not fully supported -- see "IPv6 Warning" below
->   - Other non-Linux operating systems are not supported
+>   - Other non-Linux operating systems are not supported*
 >
 > - Poetry [^3]
 > - Python >= 3.9
+
+<sub>*If using a Windows machine, follow the same steps as below on a Linux VM.</sub>
 
 There are two recommended ways of running the project:
 

--- a/iso15118/secc/transport/udp_server.py
+++ b/iso15118/secc/transport/udp_server.py
@@ -72,6 +72,10 @@ class UDPServer(asyncio.DatagramProtocol):
             full_ipv6_address = await get_link_local_full_addr(SDP_SERVER_PORT, iface)
             sock.bind(full_ipv6_address)
         else:
+            # Required if running on a Linux VM on Windows
+            if not hasattr(socket, "SO_BINDTODEVICE"):
+                socket.SO_BINDTODEVICE = 25
+
             sock.setsockopt(
                 socket.SOL_SOCKET,
                 socket.SO_BINDTODEVICE,


### PR DESCRIPTION
- While testing on VM, the following lines had to be added for UDP server to come up.
```
 if not hasattr(socket, "SO_BINDTODEVICE"):
    socket.SO_BINDTODEVICE = 25
```
- Added a comment in readme suggesting running the project on a VM if using Windows.
