### PR TITLE
AB#3740: Removed check in SalesTariff validator

### DIFF
--- a/iso15118/shared/messages/iso15118_2/datatypes.py
+++ b/iso15118/shared/messages/iso15118_2/datatypes.py
@@ -552,13 +552,6 @@ class SalesTariff(BaseModel):
                 "'num_e_price_levels' is not provided."
             )
 
-        if e_price_levels != values["num_e_price_levels"]:
-            raise ValueError(
-                "The amount of distinct e_price_levels "
-                f"{e_price_levels} does not match "
-                f"num_e_price_levels "
-                f"({values['num_e_price_levels']})"
-            )
         return value
 
     @validator("sales_tariff_id")


### PR DESCRIPTION
Summary:
NumEPriceLevels is the distinct price levels used across all SalesTariff entries. 
The validation assumed that NumEPriceLevels would be equal to the count of SalesTariff entries. This would be true only if every SalesTariff entry has as different price level. As the same price level could apply to two different SalesTariff entry, this check could wrongly fail the validation. Have removed the check. This issue was reported [here](https://github.com/SwitchEV/iso15118/issues/114).