### PR TITLE
Feat/update docker config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ build: .generate_v2_certs
 	@# This conversion is required, otherwise we wouldn't be able to spawn the evcc start script.
 	@# @ is used as a separator and allows us to escape '/', so we can substitute the '/' itself
 	@sed -i.bkp 's@/secc/g@/evcc/g@g' iso15118/evcc/Dockerfile
+	@# Add a delay on EVCC to give SECC time to start up 
+	@sed -i 's/CMD\ \/venv\/bin\/iso15118/CMD\ echo\ "Waiting for 5 seconds to start EVCC"\ \&\&\ sleep\ 5\ \&\&\ \/venv\/bin\/iso15118/g' iso15118/evcc/Dockerfile	
 	docker-compose build
 
 # Run using dev env vars

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build: .generate_v2_certs
 	@# @ is used as a separator and allows us to escape '/', so we can substitute the '/' itself
 	@sed -i.bkp 's@/secc/g@/evcc/g@g' iso15118/evcc/Dockerfile
 	@# Add a delay on EVCC to give SECC time to start up 
-	@sed -i 's/CMD\ \/venv\/bin\/iso15118/CMD\ echo\ "Waiting for 5 seconds to start EVCC"\ \&\&\ sleep\ 5\ \&\&\ \/venv\/bin\/iso15118/g' iso15118/evcc/Dockerfile	
+	@sed -i'.bkp' -e 's@CMD /venv/bin/iso15118@CMD echo "Waiting for 5 seconds to start EVCC" \&\& sleep 5 \&\& /venv/bin/iso15118@g' iso15118/evcc/Dockerfile
 	docker-compose build
 
 # Run using dev env vars

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The primary dependencies to install the project are the following:
 > - Linux
 >
 >   - MacOS is not fully supported -- see "IPv6 Warning" below
->   - Other non-Linux operating systems are not supported*
+>   - Windows is supported using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+>   - Other non-Linux operating systems are not supported
 >
 > - Poetry [^3]
 > - Python >= 3.9

--- a/iso15118/secc/transport/tcp_server.py
+++ b/iso15118/secc/transport/tcp_server.py
@@ -84,7 +84,10 @@ class TCPServer(asyncio.Protocol):
 
         MAX_RETRIES: int = 3
         BACK_OFF_SECONDS: float = 0.5
-
+        # Note: When the socket is being created inside a container,
+        # sometimes the network interface is not ready yet and the binding
+        # process fails the first time.
+        # Therefore, a wait-and-retry block has been added.
         for i in range(MAX_RETRIES):
             # Initialise socket for IPv6 TCP packets
             # Address family (determines network layer protocol, here IPv6)

--- a/template.Dockerfile
+++ b/template.Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONFAULTHANDLER=1 \
   PIP_NO_CACHE_DIR=1 \
   PIP_DISABLE_PIP_VERSION_CHECK=1 \
   PIP_DEFAULT_TIMEOUT=100 \
-  POETRY_VERSION=1.1.11 \
+  POETRY_VERSION=1.3.2 \
   VIRTUALENV_PIP=21.2.1 \
   MYPY_VERSION=0.930
 
@@ -46,6 +46,7 @@ RUN /venv/bin/pip install dist/*.whl
 
 # Replace with in-container cert generation DevOps#2664
 COPY --from=build /usr/src/app/iso15118/shared/pki/ /usr/src/app/iso15118/shared/pki/
+COPY --from=build /usr/src/app/iso15118/shared/examples/evcc/iso15118_2/ /usr/src/app/iso15118/shared/examples/evcc/iso15118_2/
 
 RUN /venv/bin/pip install aiofile
 # This will run the entrypoint script defined in the pyproject.toml


### PR DESCRIPTION
This PR includes:
- Updated Dockefile:
  - Poetry version on the dockerfile to build and run ISO15118 from containers.
  - Copy EVCC example configuration. 
- A retry/backoff block when binding the TCP sockets server to the network interfaces in case the process fails.

fixes #192, fixes #194