### PR TITLE
Start TCP server after an SDP request is received.

### DIFF
--- a/iso15118/secc/comm_session_handler.py
+++ b/iso15118/secc/comm_session_handler.py
@@ -285,7 +285,6 @@ class CommunicationSessionHandler:
                     try:
                         await self.end_current_session(notification.peer_ip_address)
                     except KeyError:
-                        # TODO Need to check why this KeyError happens
                         pass
                 else:
                     logger.warning(
@@ -308,7 +307,7 @@ class CommunicationSessionHandler:
         self.tcp_server_handler = None
         self.udp_server.resume_udp_server()
 
-    async def start_tcp_server(self, tls_enabled: bool):
+    async def start_tcp_server(self, with_tls: bool):
         if self.tcp_server_handler is not None:
             """A TCP server is already available, ready to respond.
             (Perhaps created when the last SDP request was received.)
@@ -318,7 +317,7 @@ class CommunicationSessionHandler:
         server_ready_event: asyncio.Event = asyncio.Event()
         self.status_event_list.clear()
         self.status_event_list.append(server_ready_event)
-        if tls_enabled:
+        if with_tls:
             self.tcp_server_handler = asyncio.create_task(
                 self.tcp_server.start_tls(server_ready_event)
             )

--- a/iso15118/shared/messages/sdp.py
+++ b/iso15118/shared/messages/sdp.py
@@ -243,7 +243,7 @@ def create_sdp_response(
     sdp_request: Union[SDPRequest, SDPRequestWireless],
     ip_address: bytes,
     port: int,
-    enforced_security: bool,
+    tls_enabled: bool,
 ) -> Union[SDPResponse, SDPResponseWireless]:
     """
     Creates an SDP response based on the incoming SDP request
@@ -252,7 +252,7 @@ def create_sdp_response(
         sdp_request: The SDP request received from the UDP client
         ip_address: The IP address of the TCP server
         port: The port of the TCP or TLS server
-        enforced_security: Whether or not the SECC enforces TLS
+        tls_enabled: Indicates if a TLS enabled server is available on SECC
 
     Returns:
         An SDPResponse or an SDPResponseWireless, depending on the SDP
@@ -260,10 +260,10 @@ def create_sdp_response(
     """
     sdp_response = None
 
-    if enforced_security:
+    if tls_enabled:
         security = Security.TLS
     else:
-        security = sdp_request.security
+        security = Security.NO_TLS
 
     if isinstance(sdp_request, SDPRequest):
         sdp_response = SDPResponse(ip_address, port, security, Transport.TCP)


### PR DESCRIPTION
Summary of changes:
1. When iso15118 starts up only UDP server is started.
2. When an SDP request is received, depending on the security setting in the request, either a TCP or TLS server is started. If TLS is requested, but a TLS server can't be started (maybe seccLeaf/cpoCertChain are not available), a TCP server is started - the SDP response reflects the type of TCP server available.
3. Once the first message is received over TCP connection, UDP server if paused.
4. At the end of the session, TCP server is killed and UDP resumes listening for SDP requests.

One minor change [V2GCommunicationSession](https://github.com/SwitchEV/iso15118/blob/d3e38dfbcf1c4fab65476c684a44bf34c09519ab/iso15118/shared/comm_session.py#L279) - we were relying on `self.writer.get_extra_info('peername')` to get the ip address of the remote connection - this is used as a key in `self.comm_sessions` dictionary. However, when the connection is reset, `self.writer.get_extra_info('peername')` would return None and any look up in the dictionary would fail. The call has been replaced with a member variable that holds the value (populated when the peer connection is available).
