### PR TITLE
terminate java gateway on exit

### DIFF
--- a/iso15118/shared/exificient_exi_codec.py
+++ b/iso15118/shared/exificient_exi_codec.py
@@ -21,7 +21,7 @@ class ExificientEXICodec(IEXICodec):
         logging.getLogger("py4j").setLevel(logging.CRITICAL)
         self.gateway = JavaGateway.launch_gateway(
             classpath=JAR_FILE_PATH,
-            die_on_exit=False,
+            die_on_exit=True,
             javaopts=["--add-opens", "java.base/java.lang=ALL-UNNAMED"],
         )
 


### PR DESCRIPTION
I ran into a situation running the iso15118 stack where the java background process spawned by JavaGateway was not getting terminated under certain conditions.  

The issue can be replicated as follows:
1. run evcc demo
2. kill the top level python process with -9
=> the java process remains

I ran into this issue while using a unit test framework and ended up with 100s of java processes running in the background which eventually used up all my RAM.

This patch fixes the issue for me both in the unit test framework and when force-killing the parent process.  The die_on_exit argument causes the [die-on-broken-pipe](https://github.com/py4j/py4j/blob/9e61991c7ac0c61066486204fe94936a1ff4e186/py4j-python/src/py4j/java_gateway.py#L303) flag to be passed to the [java gateway](https://github.com/py4j/py4j/blob/9e61991c7ac0c61066486204fe94936a1ff4e186/py4j-java/src/main/java/py4j/GatewayServer.java#L860), which terminates the gateway if the stdin pipe is broken. 