### PR TITLE
Fix min_length of EVSE ID for DIN protocol

### DIFF
--- a/iso15118/shared/messages/din_spec/body.py
+++ b/iso15118/shared/messages/din_spec/body.py
@@ -105,6 +105,11 @@ class SessionSetupRes(Response):
     The SECC and the EVCC shall use the format for EVSEID as defined
     in DIN SPEC 91286.
 
+    See section 9.4.1.2.3 Table 30 in DIN SPEC 70121
+    "If an SECC cannot provide such ID data, the value of the EVSEID
+    is set to zero (00hex)."
+    => min_length = 2
+
     For EVSE ID format see section 5.3.2:
     "Each <EVSEID> has a variable length with at least five characters (one
     digit <Country Code>, three digits <Spot Operator ID>, one digit <Power Outlet ID>)
@@ -119,7 +124,7 @@ class SessionSetupRes(Response):
      as “0x49 0xA8 0x9A 0x63 0x60”.
     """
 
-    evse_id: str = Field(..., min_length=7, max_length=32, alias="EVSEID")
+    evse_id: str = Field(..., min_length=2, max_length=32, alias="EVSEID")
     datetime_now: int = Field(None, alias="DateTimeNow")
 
 

--- a/tests/dinspec/evcc/evcc_mock_messages.py
+++ b/tests/dinspec/evcc/evcc_mock_messages.py
@@ -1,3 +1,4 @@
+import time
 from typing import List, Optional
 
 from iso15118.shared.messages.datatypes import (
@@ -16,6 +17,7 @@ from iso15118.shared.messages.datatypes import (
 )
 from iso15118.shared.messages.din_spec.body import (
     Body,
+    SessionSetupRes,
     ChargeParameterDiscoveryRes,
     ContractAuthenticationRes,
     CurrentDemandRes,
@@ -342,4 +344,16 @@ def get_welding_detection_on_going_message():
     return V2GMessage(
         header=MessageHeader(session_id=MOCK_SESSION_ID),
         body=Body(welding_detection_res=welding_detection),
+    )
+
+
+def get_session_setup_evseid_zero():
+    session_setup: SessionSetupRes = SessionSetupRes(
+        response_code=ResponseCode.OK,
+        evse_id="00",
+        datetime_now=time.time()
+    )
+    return V2GMessage(
+        header=MessageHeader(session_id=MOCK_SESSION_ID),
+        body=Body(session_setup_res=session_setup),
     )

--- a/tests/dinspec/evcc/evcc_mock_messages.py
+++ b/tests/dinspec/evcc/evcc_mock_messages.py
@@ -17,13 +17,13 @@ from iso15118.shared.messages.datatypes import (
 )
 from iso15118.shared.messages.din_spec.body import (
     Body,
-    SessionSetupRes,
     ChargeParameterDiscoveryRes,
     ContractAuthenticationRes,
     CurrentDemandRes,
     PowerDeliveryRes,
     ServiceDiscoveryRes,
     ServicePaymentSelectionRes,
+    SessionSetupRes,
     WeldingDetectionRes,
 )
 from iso15118.shared.messages.din_spec.datatypes import (
@@ -349,9 +349,7 @@ def get_welding_detection_on_going_message():
 
 def get_session_setup_evseid_zero():
     session_setup: SessionSetupRes = SessionSetupRes(
-        response_code=ResponseCode.OK,
-        evse_id="00",
-        datetime_now=time.time()
+        response_code=ResponseCode.OK, evse_id="00", datetime_now=time.time()
     )
     return V2GMessage(
         header=MessageHeader(session_id=MOCK_SESSION_ID),

--- a/tests/dinspec/evcc/test_dinspec_evcc_states.py
+++ b/tests/dinspec/evcc/test_dinspec_evcc_states.py
@@ -8,6 +8,7 @@ from iso15118.evcc import EVCCConfig
 from iso15118.evcc.comm_session_handler import EVCCCommunicationSession
 from iso15118.evcc.controller.simulator import SimEVController
 from iso15118.evcc.states.din_spec_states import (
+    SessionSetup,
     CableCheck,
     ChargeParameterDiscovery,
     ContractAuthentication,
@@ -21,6 +22,7 @@ from iso15118.shared.messages.enums import AuthEnum, EnergyTransferModeEnum, Pro
 from iso15118.shared.notifications import StopNotification
 from iso15118.shared.states import Terminate
 from tests.dinspec.evcc.evcc_mock_messages import (
+    get_session_setup_evseid_zero,
     get_charge_parameter_discovery_message,
     get_charge_parameter_discovery_on_going_message,
     get_contract_authentication_message,
@@ -164,6 +166,13 @@ class TestEvScenarios:
             message=get_charge_parameter_discovery_on_going_message()
         )
         assert charge_parameter_discovery.next_state is Terminate
+
+    async def test_session_setup_to_service_discovery(self):
+        session_setup = SessionSetup(self.comm_session_mock)
+        await session_setup.process_message(
+            message=get_session_setup_evseid_zero()
+        )
+        assert session_setup.next_state is ServiceDiscovery
 
     async def cable_check_req_to_pre_charge(self):
         pass

--- a/tests/dinspec/evcc/test_dinspec_evcc_states.py
+++ b/tests/dinspec/evcc/test_dinspec_evcc_states.py
@@ -8,7 +8,6 @@ from iso15118.evcc import EVCCConfig
 from iso15118.evcc.comm_session_handler import EVCCCommunicationSession
 from iso15118.evcc.controller.simulator import SimEVController
 from iso15118.evcc.states.din_spec_states import (
-    SessionSetup,
     CableCheck,
     ChargeParameterDiscovery,
     ContractAuthentication,
@@ -16,13 +15,13 @@ from iso15118.evcc.states.din_spec_states import (
     PowerDelivery,
     ServiceDiscovery,
     ServicePaymentSelection,
+    SessionSetup,
     WeldingDetection,
 )
 from iso15118.shared.messages.enums import AuthEnum, EnergyTransferModeEnum, Protocol
 from iso15118.shared.notifications import StopNotification
 from iso15118.shared.states import Terminate
 from tests.dinspec.evcc.evcc_mock_messages import (
-    get_session_setup_evseid_zero,
     get_charge_parameter_discovery_message,
     get_charge_parameter_discovery_on_going_message,
     get_contract_authentication_message,
@@ -34,6 +33,7 @@ from tests.dinspec.evcc.evcc_mock_messages import (
     get_service_discovery_message_payment_service_not_offered,
     get_service_payment_selection_fail_message,
     get_service_payment_selection_message,
+    get_session_setup_evseid_zero,
     get_v2g_message_current_demand_current_limit_not_achieved,
     get_welding_detection_on_going_message,
 )
@@ -169,9 +169,7 @@ class TestEvScenarios:
 
     async def test_session_setup_to_service_discovery(self):
         session_setup = SessionSetup(self.comm_session_mock)
-        await session_setup.process_message(
-            message=get_session_setup_evseid_zero()
-        )
+        await session_setup.process_message(message=get_session_setup_evseid_zero())
         assert session_setup.next_state is ServiceDiscovery
 
     async def cable_check_req_to_pre_charge(self):


### PR DESCRIPTION
See section 9.4.1.2.3 Table 30 in DIN SPEC 70121
"If an SECC cannot provide such ID data, the value of the EVSEID is set to zero (00hex)."
=> EVSE ID min_length = 2