### PR TITLE
JTT-52: Stop charging if state C not detected in PowerDelivery state.

### DIFF
--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -3,7 +3,7 @@ This module contains the SECC's States used to process the EVCC's incoming
 V2GMessage objects of the ISO 15118-20 protocol, from SessionSetupReq to
 SessionStopReq.
 """
-
+import asyncio
 import logging
 import time
 from typing import List, Optional, Tuple, Type, Union
@@ -20,6 +20,7 @@ from iso15118.shared.messages.enums import (
     AuthEnum,
     AuthorizationStatus,
     ControlMode,
+    CpState,
     EVSEProcessing,
     IsolationLevel,
     ISOV20PayloadTypes,
@@ -1063,8 +1064,15 @@ class PowerDelivery(StateSECC):
                 # [V2G20 - 847] The EVCC shall signal CP State C or D no later than 250
                 # ms after sending the first PowerDeliveryReq with ChargeProgress
                 # equals "Start" within V2G communication session.
-                # TODO: We may need to check the CP state is C or D before
-                #  closing the contactors.
+                if not await self.wait_for_state_c_or_d():
+                    self.stop_state_machine(
+                        "[V2G20-847]: State C/D not detected in PowerDelivery within"
+                        " the allotted 250 ms.",
+                        message,
+                        ResponseCode.FAILED,
+                    )
+                    return
+
                 if not await self.comm_session.evse_controller.is_contactor_closed():
                     self.stop_state_machine(
                         "Contactor didnt close",
@@ -1110,6 +1118,35 @@ class PowerDelivery(StateSECC):
             Namespace.ISO_V20_COMMON_MSG,
             ISOV20PayloadTypes.MAINSTREAM,
         )
+
+    async def wait_for_state_c_or_d(self) -> bool:
+        # [V2G2 - 847] The EV shall signal CP State C or D no later than 250ms
+        # after sending the first PowerDeliveryReq with ChargeProgress equals
+        # "Start" within V2G Communication SessionPowerDeliveryReq.
+        STATE_C_TIMEOUT = 0.25
+
+        async def check_state():
+            while await self.comm_session.evse_controller.get_cp_state() not in [
+                CpState.C2,
+                CpState.D2,
+            ]:
+                await asyncio.sleep(0.05)
+            logger.debug(
+                f"State is " f"{await self.comm_session.evse_controller.get_cp_state()}"
+            )
+            return True
+
+        try:
+            return await asyncio.wait_for(
+                check_state(),
+                timeout=STATE_C_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            # try one more time to get the latest state
+            return await self.comm_session.evse_controller.get_cp_state() in [
+                CpState.C2,
+                CpState.D2,
+            ]
 
     def check_power_profile(self, power_profile: EVPowerProfile) -> ResponseCode:
         # TODO Check the power profile for any violation

--- a/tests/iso15118_20/secc/test_iso15118_20_dc_states.py
+++ b/tests/iso15118_20/secc/test_iso15118_20_dc_states.py
@@ -1,3 +1,4 @@
+from datetime import time
 from typing import Type
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -8,6 +9,7 @@ from iso15118.secc.controller.simulator import SimEVSEController
 from iso15118.secc.failed_responses import init_failed_responses_iso_v20
 from iso15118.secc.states.iso15118_20_states import (
     DCCableCheck,
+    DCChargeLoop,
     DCChargeParameterDiscovery,
     DCPreCharge,
     PowerDelivery,
@@ -15,22 +17,28 @@ from iso15118.secc.states.iso15118_20_states import (
 )
 from iso15118.shared.messages.enums import (
     ControlMode,
+    CpState,
     EnergyTransferModeEnum,
     IsolationLevel,
     Protocol,
     ServiceV20,
 )
-from iso15118.shared.messages.iso15118_20.common_messages import SelectedEnergyService
-from iso15118.shared.messages.iso15118_20.common_types import Processing
+from iso15118.shared.messages.iso15118_20.common_messages import (
+    ChargeProgress,
+    SelectedEnergyService,
+)
+from iso15118.shared.messages.iso15118_20.common_types import MessageHeader, Processing
 from iso15118.shared.notifications import StopNotification
 from iso15118.shared.states import State, Terminate
 from tests.dinspec.secc.test_dinspec_secc_states import MockWriter
 from tests.iso15118_20.secc.test_messages import (
     get_cable_check_req,
+    get_power_delivery_req,
     get_precharge_req,
     get_schedule_exchange_req_message,
     get_v2g_message_dc_charge_parameter_discovery_req,
 )
+from tests.tools import MOCK_SESSION_ID
 
 
 @patch("iso15118.shared.states.EXI.to_exi", new=Mock(return_value=b"01"))
@@ -163,3 +171,46 @@ class TestEvScenarios:
     async def test_15118_20_power_delivery(self):
         # TODO
         pass
+
+    @pytest.mark.parametrize(
+        "control_mode, next_state, selected_energy_service, cp_state",
+        [
+            (
+                ControlMode.DYNAMIC,
+                DCChargeLoop,
+                SelectedEnergyService(
+                    service=ServiceV20.DC, is_free=True, parameter_set=None
+                ),
+                CpState.D2,
+            ),
+            (
+                ControlMode.DYNAMIC,
+                DCChargeLoop,
+                SelectedEnergyService(
+                    service=ServiceV20.DC, is_free=True, parameter_set=None
+                ),
+                CpState.C2,
+            ),
+            (
+                ControlMode.DYNAMIC,
+                Terminate,
+                SelectedEnergyService(
+                    service=ServiceV20.DC, is_free=True, parameter_set=None
+                ),
+                CpState.B2,
+            ),
+        ],
+    )
+    async def test_power_delivery_state_check(
+        self, control_mode, next_state, selected_energy_service, cp_state
+    ):
+        self.comm_session.control_mode = control_mode
+        self.comm_session.selected_energy_service = selected_energy_service
+        power_delivery = PowerDelivery(self.comm_session)
+        self.comm_session.evse_controller.get_cp_state = AsyncMock(
+            return_value=cp_state
+        )
+        await power_delivery.process_message(
+            message=get_power_delivery_req(Processing.FINISHED, ChargeProgress.START)
+        )
+        assert power_delivery.next_state is next_state

--- a/tests/iso15118_20/secc/test_iso15118_20_dc_states.py
+++ b/tests/iso15118_20/secc/test_iso15118_20_dc_states.py
@@ -1,4 +1,3 @@
-from datetime import time
 from typing import Type
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -27,7 +26,7 @@ from iso15118.shared.messages.iso15118_20.common_messages import (
     ChargeProgress,
     SelectedEnergyService,
 )
-from iso15118.shared.messages.iso15118_20.common_types import MessageHeader, Processing
+from iso15118.shared.messages.iso15118_20.common_types import Processing
 from iso15118.shared.notifications import StopNotification
 from iso15118.shared.states import State, Terminate
 from tests.dinspec.secc.test_dinspec_secc_states import MockWriter
@@ -38,7 +37,6 @@ from tests.iso15118_20.secc.test_messages import (
     get_schedule_exchange_req_message,
     get_v2g_message_dc_charge_parameter_discovery_req,
 )
-from tests.tools import MOCK_SESSION_ID
 
 
 @patch("iso15118.shared.states.EXI.to_exi", new=Mock(return_value=b"01"))

--- a/tests/iso15118_20/secc/test_messages.py
+++ b/tests/iso15118_20/secc/test_messages.py
@@ -5,6 +5,7 @@ from iso15118.shared.messages.iso15118_20.common_messages import (
     AuthorizationReq,
     ChargeProgress,
     ContractCertificateChain,
+    DynamicEVPowerProfile,
     DynamicScheduleExchangeReqParams,
     EIMAuthReqParams,
     EVPowerProfile,
@@ -160,7 +161,7 @@ def get_power_delivery_req(processing: Processing, charge_progress: ChargeProgre
         ),
         ev_processing=processing,
         charge_progress=charge_progress,
-        scheduled_profile=EVPowerProfile(
+        ev_power_profile=EVPowerProfile(
             time_anchor=0,
             entry_list=EVPowerProfileEntryList(
                 entries=[
@@ -169,5 +170,6 @@ def get_power_delivery_req(processing: Processing, charge_progress: ChargeProgre
                     )
                 ]
             ),
+            dynamic_profile=DynamicEVPowerProfile(),
         ),
     )


### PR DESCRIPTION
[V2G20 - 847] The EVCC shall signal CP State C or D no later than 250 ms after sending the first PowerDeliveryReq with ChargeProgress equals "Start" within V2G communication session.