### PR TITLE
ScheduleExchange(StateEVCC_bug)

### DIFF
--- a/iso15118/evcc/states/iso15118_20_states.py
+++ b/iso15118/evcc/states/iso15118_20_states.py
@@ -841,7 +841,7 @@ class ScheduleExchange(StateEVCC):
 
             # Information from EV to show if charging or discharging is planned
             bpt_channel_selection = None
-            if self.comm_session.selected_energy_service in (
+            if self.comm_session.selected_energy_service.service in (
                 ServiceV20.AC_BPT,
                 ServiceV20.DC_BPT,
             ):


### PR DESCRIPTION
Dear Authors:
       I change class ScheduleExchange(StateEVCC)   
       
       if self.comm_session.selected_energy_service in (
                ServiceV20.AC_BPT,
                ServiceV20.DC_BPT,
            ):
            
       to
       
       if self.comm_session.selected_energy_service.service in (
              ServiceV20.AC_BPT,
              ServiceV20.DC_BPT,
          ):
Otherwise, ChannelSelection.DISCHARGE or ChannelSelection.CHARGE cannot be determined.


Many thanks,
Mike