### PR TITLE
Report session stop reason

### DIFF
--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -871,3 +871,10 @@ class EVSEControllerInterface(ABC):
         ready to start charging.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    async def session_ended(self, current_state: str, reason: str):
+        """
+        Indicate the reason for stopping charging.
+        """
+        raise NotImplementedError

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -1144,3 +1144,13 @@ class SimEVSEController(EVSEControllerInterface):
         Overrides EVSEControllerInterface.ready_to_charge().
         """
         return True
+
+    async def session_ended(self, current_state: str, reason: str):
+        """
+        Reports the state and reason where the session ended.
+
+        @param current_state: The current SDP/SAP/DIN/ISO15118-2/ISO15118-20 state.
+        @param reason: Reason for ending the session.
+        @param last_message: The last message that was either sent/received.
+        """
+        logger.info(f"Session ended in {current_state} ({reason}).")

--- a/iso15118/shared/comm_session.py
+++ b/iso15118/shared/comm_session.py
@@ -407,6 +407,7 @@ class V2GCommunicationSession(SessionStateMachine):
         if hasattr(self.comm_session, "evse_controller"):
             evse_controller = self.comm_session.evse_controller
             await evse_controller.update_data_link(terminate_or_pause)
+            await evse_controller.session_ended(str(self.current_state), reason)
         logger.info(f"{terminate_or_pause}d the data link")
         await asyncio.sleep(3)
         try:


### PR DESCRIPTION
Report session stop reason. When [stop()](https://github.com/SwitchEV/iso15118/blob/e73c5903df92e419b8bc88a61e02626fa62721a9/iso15118/shared/comm_session.py#L376) is called, the reason is passed to evse_controller.