### PR TITLE
JTT-458 Fix json logging in iso15118

### DIFF
--- a/iso15118/shared/exi_codec.py
+++ b/iso15118/shared/exi_codec.py
@@ -244,7 +244,7 @@ class EXI:
                                    {exc}"
             ) from exc
 
-        if shared_settings[SettingKey.MESSAGE_LOG_EXI]:
+        if shared_settings[SettingKey.MESSAGE_LOG_JSON]:
             logger.info(f"Message to encode (ns={protocol_ns}): {msg_content}")
 
         try:


### PR DESCRIPTION
Broken in last release. Json logging was moved to be behind log EXI env variable.