### PR TITLE
jtt-550_ignore_incorrect_mo_root_on_disk

### DIFF
--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -967,7 +967,7 @@ class PaymentDetails(StateSECC):
 
             try:
                 verify_certs(leaf_cert, sub_ca_certs, root_cert)
-            except CertSignatureError as cse:
+            except CertSignatureError:
                 # This error means there was an error while validating the parent-child
                 # relationship in the cert chain. This could also very well be
                 # a limitation on the SECC that the root certificate present

--- a/iso15118/shared/security.py
+++ b/iso15118/shared/security.py
@@ -530,8 +530,6 @@ def verify_certs(
         certs_to_check: List[Certificate] = [leaf_cert]
         if len(sub_ca_der_certs) != 0:
             certs_to_check.extend(sub_ca_der_certs)
-        if root_ca_cert:
-            certs_to_check.append(root_ca_cert)
         check_validity(certs_to_check)
     except (CertNotYetValidError, CertExpiredError) as exc:
         raise exc
@@ -539,6 +537,7 @@ def verify_certs(
     if not root_ca_cert:
         logger.info("Can't validate the chain as MO root is not present.")
         return None
+
     # Step 2.a: Categorize the sub-CA certificates into sub-CA 1 and sub-CA 2.
     #           A sub-CA 2 certificate's profile has its PathLength extension
     #           attribute set to 0, whereas a sub-CA 1 certificate's profile has

--- a/tests/iso15118_2/secc/states/test_iso15118_2_states.py
+++ b/tests/iso15118_2/secc/states/test_iso15118_2_states.py
@@ -368,10 +368,10 @@ class TestV2GSessionScenarios:
                 payment_details.message.body.payment_details_res.response_code
                 == expected_response_code
             )
-        # if is_authorized_return_value is not None:
-        #     mock_is_authorized.assert_called_once()
-        # else:
-        #     mock_is_authorized.assert_not_called()
+        if is_authorized_return_value is not None:
+            mock_is_authorized.assert_called_once()
+        else:
+            mock_is_authorized.assert_not_called()
 
     @pytest.mark.parametrize(
         "auth_type, is_authorized_return_value, expected_next_state,"

--- a/tests/iso15118_2/secc/states/test_iso15118_2_states.py
+++ b/tests/iso15118_2/secc/states/test_iso15118_2_states.py
@@ -309,8 +309,7 @@ class TestV2GSessionScenarios:
         #     mock_is_authorized.assert_not_called()
 
     @patch(
-        "iso15118.secc.states.iso15118_2_states.PaymentDetails._mobility_operator_root_cert_path"
-        # noqa
+        "iso15118.secc.states.iso15118_2_states.PaymentDetails._mobility_operator_root_cert_path"  # noqa
     )
     @pytest.mark.parametrize(
         "mo_root, "
@@ -343,7 +342,7 @@ class TestV2GSessionScenarios:
             ),
         ],
     )
-    async def test_payment_details_next_state_on_payment_details_contract_variants_incorrect_mo_root(
+    async def test_payment_details_next_state_on_payment_details_contract_variants_incorrect_mo_root(  # noqa
         self,
         mock_mo_root_path,
         mo_root,


### PR DESCRIPTION
Avoid failing if local chain validation fails in PaymentDetails. This will still be performed in the backend. Tests added.