### PR TITLE
Added optional is_precharge flag to send_charging_command

### DIFF
--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -727,6 +727,7 @@ class EVSEControllerInterface(ABC):
         self,
         ev_target_voltage: Optional[float],
         ev_target_current: Optional[float],
+        is_precharge: bool = False,
         is_session_bpt: bool = False,
     ):
         """

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -879,6 +879,7 @@ class SimEVSEController(EVSEControllerInterface):
         self,
         ev_target_voltage: Optional[float],
         ev_target_current: Optional[float],
+        is_precharge: bool = False,
         is_session_bpt: bool = False,
     ):
         pass

--- a/iso15118/secc/states/din_spec_states.py
+++ b/iso15118/secc/states/din_spec_states.py
@@ -610,6 +610,7 @@ class PreCharge(StateSECC):
             await self.comm_session.evse_controller.send_charging_command(
                 ev_data_context.target_voltage,
                 ev_data_context.target_current,
+                is_precharge=True,
             )
         except asyncio.TimeoutError:
             self.stop_state_machine(

--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -1697,8 +1697,7 @@ class DCPreCharge(StateSECC):
             try:
                 # Current is set to 0 as that is not used for PreCharge
                 await self.comm_session.evse_controller.send_charging_command(
-                    ev_data_context.target_voltage,
-                    0,
+                    ev_data_context.target_voltage, 0, is_precharge=True
                 )
             except asyncio.TimeoutError:
                 self.stop_state_machine(

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -2358,6 +2358,7 @@ class PreCharge(StateSECC):
             await self.comm_session.evse_controller.send_charging_command(
                 ev_data_context.target_voltage,
                 ev_data_context.target_current,
+                is_precharge=True,
             )
         except asyncio.TimeoutError:
             self.stop_state_machine(


### PR DESCRIPTION
Added is_precharge flag to send_charging_command. Required as we use the same method during charging loop and precharge.