### PR TITLE
EVCC enable charging and fix for DIN EVSE initiated stop

### DIFF
--- a/iso15118/evcc/controller/interface.py
+++ b/iso15118/evcc/controller/interface.py
@@ -659,3 +659,14 @@ class EVControllerInterface(ABC):
         - DIN SPEC 70121
         """
         raise NotImplementedError
+
+    @abstractmethod
+    async def enable_charging(self, enabled: bool) -> None:
+        """
+        Enables charging for the EVCC.
+        Can be used as an indication to go to state C
+        Relevant for:
+        - DIN SPEC 70121
+        - ISO 15118-2
+        - ISO 15118-20
+        """

--- a/iso15118/evcc/controller/simulator.py
+++ b/iso15118/evcc/controller/simulator.py
@@ -722,3 +722,7 @@ class SimEVController(EVControllerInterface):
     async def get_target_voltage(self) -> RationalNumber:
         """Overrides EVControllerInterface.get_target_voltage()."""
         return RationalNumber(exponent=3, value=20)
+
+    async def enable_charging(self, enabled: bool) -> None:
+        """Overrides EVControllerInterface.enable_charging()."""
+        pass

--- a/iso15118/evcc/states/din_spec_states.py
+++ b/iso15118/evcc/states/din_spec_states.py
@@ -19,7 +19,6 @@ from iso15118.shared.messages.datatypes import (
     DCEVChargeParams,
     DCEVSEStatus,
     DCEVSEStatusCode,
-    EVSENotification,
     SelectedService,
     SelectedServiceList,
 )

--- a/iso15118/evcc/states/din_spec_states.py
+++ b/iso15118/evcc/states/din_spec_states.py
@@ -395,8 +395,7 @@ class ChargeParameterDiscovery(StateEVCC):
             )
 
             self.comm_session.selected_schedule = schedule_id
-
-            # TODO Set CP state to C max. 250 ms after sending PowerDeliveryReq
+            await self.comm_session.ev_controller.enable_charging(True)
         else:
             logger.debug(
                 "SECC is still processing the proposed charging "
@@ -645,6 +644,7 @@ class PowerDelivery(StateEVCC):
                 Namespace.DIN_MSG_DEF,
             )
         else:
+            await self.comm_session.ev_controller.enable_charging(False)
             self.create_next_message(
                 WeldingDetection,
                 await self.build_welding_detection_req(),
@@ -709,10 +709,8 @@ class CurrentDemand(StateEVCC):
         current_demand_res: CurrentDemandRes = msg.body.current_demand_res
         dc_evse_status: DCEVSEStatus = current_demand_res.dc_evse_status
 
-        # "Charging stop" can be initiated by either party
-        # - by EVSE via EVSENotification
-        # - by EV itself where it sets ready_to_charge to False.
-        if dc_evse_status.evse_notification == EVSENotification.STOP_CHARGING:
+        # EVSE status must always be EVSE ready
+        if dc_evse_status.evse_status_code is not DCEVSEStatusCode.EVSE_READY:
             logger.debug("EVSE Notification received requesting to stop charging.")
             await self.stop_charging()
         elif await self.comm_session.ev_controller.continue_charging():

--- a/iso15118/evcc/states/iso15118_20_states.py
+++ b/iso15118/evcc/states/iso15118_20_states.py
@@ -1576,7 +1576,7 @@ class DCPreCharge(StateEVCC):
                 bpt_channel_selection = ChannelSelection.DISCHARGE
             else:
                 bpt_channel_selection = ChannelSelection.CHARGE
-        await self.comm_session.ev_controller.enable_charging(True)make 
+        await self.comm_session.ev_controller.enable_charging(True)
         power_delivery_req = PowerDeliveryReq(
             header=MessageHeader(
                 session_id=self.comm_session.session_id,

--- a/iso15118/evcc/states/iso15118_20_states.py
+++ b/iso15118/evcc/states/iso15118_20_states.py
@@ -923,6 +923,7 @@ class PowerDelivery(StateEVCC):
             ChargingSession.SERVICE_RENEGOTIATION,
             ChargingSession.TERMINATE,
         ):
+            await self.comm_session.ev_controller.enable_charging(False)
             if self.comm_session.selected_energy_service.service in [
                 ServiceV20.DC,
                 ServiceV20.DC_BPT,

--- a/iso15118/evcc/states/iso15118_20_states.py
+++ b/iso15118/evcc/states/iso15118_20_states.py
@@ -855,6 +855,7 @@ class ScheduleExchange(StateEVCC):
                         bpt_channel_selection = ChannelSelection.CHARGE
 
             if self.comm_session.selected_charging_type_is_ac:
+                await self.comm_session.ev_controller.enable_charging(True)
                 power_delivery_req = PowerDeliveryReq(
                     header=MessageHeader(
                         session_id=self.comm_session.session_id,
@@ -1575,7 +1576,7 @@ class DCPreCharge(StateEVCC):
                 bpt_channel_selection = ChannelSelection.DISCHARGE
             else:
                 bpt_channel_selection = ChannelSelection.CHARGE
-
+        await self.comm_session.ev_controller.enable_charging(True)make 
         power_delivery_req = PowerDeliveryReq(
             header=MessageHeader(
                 session_id=self.comm_session.session_id,

--- a/iso15118/evcc/states/iso15118_2_states.py
+++ b/iso15118/evcc/states/iso15118_2_states.py
@@ -770,7 +770,7 @@ class ChargeParameterDiscovery(StateEVCC):
             ) = await ev_controller.process_sa_schedules_v2(
                 charge_params_res.sa_schedule_list.schedule_tuples
             )
-
+            await self.comm_session.ev_controller.enable_charging(True)
             if self.comm_session.selected_charging_type_is_ac:
                 power_delivery_req = PowerDeliveryReq(
                     charge_progress=charge_progress,
@@ -798,7 +798,7 @@ class ChargeParameterDiscovery(StateEVCC):
 
             self.comm_session.selected_schedule = schedule_id
 
-            # TODO Set CP state to C max. 250 ms after sending PowerDeliveryReq
+            await self.comm_session.ev_controller.enable_charging(True)
         else:
             logger.debug(
                 "SECC is still processing the proposed charging "
@@ -874,6 +874,7 @@ class PowerDelivery(StateEVCC):
                 Namespace.ISO_V2_MSG_DEF,
             )
         elif self.comm_session.charging_session_stop_v2:
+            await self.comm_session.ev_controller.enable_charging(False)
             welding_detection_req = WeldingDetectionReq(
                 dc_ev_status=await self.comm_session.ev_controller.get_dc_ev_status()
             )

--- a/tests/dinspec/evcc/evcc_mock_messages.py
+++ b/tests/dinspec/evcc/evcc_mock_messages.py
@@ -61,10 +61,10 @@ def get_dc_evse_status():
 
 def get_dc_evse_status_stop_charging():
     return DCEVSEStatus(
-        evse_notification=EVSENotification.STOP_CHARGING,
+        evse_notification=EVSENotification.NONE,
         notification_max_delay=0,
         evse_isolation_status=IsolationLevel.VALID,
-        evse_status_code=DCEVSEStatusCode.EVSE_READY,
+        evse_status_code=DCEVSEStatusCode.EVSE_SHUTDOWN,
     )
 
 


### PR DESCRIPTION
Fixes #356 and #264 

- Added enable_charging to evcc controller interface. This gives the EVCC the opertunity to go to state C (or B)
- Fixed an issue where the wrong flag was checked when receiving current demand response for EVSE initiated shutdown (DIN only)