### PR TITLE
Fix for ChargeParameterDiscovery (TypeError occurred while processing message  in state ChargeParameterDiscovery : int() argument must be a string, a bytes-like object or a real number, not 'NoneType'. ).

### DIFF
--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -790,7 +790,9 @@ class EVSEControllerInterface(ABC):
             voltage_limit = session_limits.dc_limits.max_voltage
         else:
             ac_evse_charge_params = await self.get_ac_charge_params_v2()
-            voltage_limit = ac_evse_charge_params.evse_nominal_voltage.get_decimal_value()
+            voltage_limit = (
+                ac_evse_charge_params.evse_nominal_voltage.get_decimal_value()
+            )
         exponent, value = PhysicalValue.get_exponent_value_repr(voltage_limit)
         return PVEVSEMaxVoltageLimit(
             multiplier=exponent,

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -786,13 +786,10 @@ class EVSEControllerInterface(ABC):
         - ISO 15118-2
         """
         session_limits = self.evse_data_context.session_limits
-        if self.evse_data_context.current_type == CurrentType.DC:
-            voltage_limit = session_limits.dc_limits.max_voltage
+        if self.evse_data_context.current_type == CurrentType.AC:
+            voltage_limit = self.evse_data_context.nominal_voltage
         else:
-            ac_evse_charge_params = await self.get_ac_charge_params_v2()
-            voltage_limit = (
-                ac_evse_charge_params.evse_nominal_voltage.get_decimal_value()
-            )
+            voltage_limit = session_limits.dc_limits.max_voltage
         exponent, value = PhysicalValue.get_exponent_value_repr(voltage_limit)
         return PVEVSEMaxVoltageLimit(
             multiplier=exponent,

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -789,7 +789,8 @@ class EVSEControllerInterface(ABC):
         if self.evse_data_context.current_type == CurrentType.DC:
             voltage_limit = session_limits.dc_limits.max_voltage
         else:
-            voltage_limit = 230
+            ac_evse_charge_params = await self.get_ac_charge_params_v2()
+            voltage_limit = ac_evse_charge_params.evse_nominal_voltage
         exponent, value = PhysicalValue.get_exponent_value_repr(voltage_limit)
         return PVEVSEMaxVoltageLimit(
             multiplier=exponent,

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -786,7 +786,10 @@ class EVSEControllerInterface(ABC):
         - ISO 15118-2
         """
         session_limits = self.evse_data_context.session_limits
-        voltage_limit = session_limits.dc_limits.max_voltage
+        if self.evse_data_context.current_type == CurrentType.DC:
+            voltage_limit = session_limits.dc_limits.max_voltage
+        else:
+            voltage_limit = 230
         exponent, value = PhysicalValue.get_exponent_value_repr(voltage_limit)
         return PVEVSEMaxVoltageLimit(
             multiplier=exponent,

--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -790,7 +790,7 @@ class EVSEControllerInterface(ABC):
             voltage_limit = session_limits.dc_limits.max_voltage
         else:
             ac_evse_charge_params = await self.get_ac_charge_params_v2()
-            voltage_limit = ac_evse_charge_params.evse_nominal_voltage
+            voltage_limit = ac_evse_charge_params.evse_nominal_voltage.get_decimal_value()
         exponent, value = PhysicalValue.get_exponent_value_repr(voltage_limit)
         return PVEVSEMaxVoltageLimit(
             multiplier=exponent,

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -1349,27 +1349,32 @@ class ChargeParameterDiscovery(StateSECC):
             return
 
         evse_data_context = self.comm_session.evse_controller.evse_data_context
+        logger.debug(f"evse_data_context : {evse_data_context}")
         ev_data_context = self.comm_session.evse_controller.ev_data_context
-
+        logger.debug(f"ev_data_context : {ev_data_context}")
         self.comm_session.selected_energy_mode = charge_params_req.requested_energy_mode
+        logger.debug(f"selected_energy_mode : {self.comm_session.selected_energy_mode}")
         self.comm_session.selected_charging_type_is_ac = (
             self.comm_session.selected_energy_mode.value.startswith("AC")
         )
-
+        logger.debug(f"selected_charging_type_is_ac : {self.comm_session.selected_charging_type_is_ac}")
         max_schedule_entries: Optional[
             int
         ] = charge_params_req.max_entries_sa_schedule_tuple
-
+        logger.debug(f"max_schedule_entries : {max_schedule_entries}")
         ac_evse_charge_params: Optional[ACEVSEChargeParameter] = None
         dc_evse_charge_params: Optional[DCEVSEChargeParameter] = None
         if charge_params_req.ac_ev_charge_parameter:
             ac_evse_charge_params = (
                 await self.comm_session.evse_controller.get_ac_charge_params_v2()
             )
+            logger.debug(f"ac_evse_charge_params : {ac_evse_charge_params}")
             evse_data_context.update_ac_charge_parameters_v2(ac_evse_charge_params)
             ev_data_context.update_ac_charge_parameters_v2(
                 charge_params_req.ac_ev_charge_parameter
             )
+            logger.debug(f"update_ac_charge_parameters_v2 : {evse_data_context}")
+            logger.debug(f"update_ac_charge_parameters_v2 : {ev_data_context}")
         else:
             dc_evse_charge_params = (
                 await self.comm_session.evse_controller.get_dc_charge_parameters_v2()
@@ -1382,17 +1387,18 @@ class ChargeParameterDiscovery(StateSECC):
         departure_time = (
             ev_data_context.departure_time if ev_data_context.departure_time else 0
         )
+        logger.debug(f"departure_time : {departure_time}")
         sa_schedule_list = await self.comm_session.evse_controller.get_sa_schedule_list(
             ev_data_context,
             self.comm_session.config.free_charging_service,
             max_schedule_entries,
             departure_time,
         )
-
+        logger.debug(f"sa_schedule_list : {sa_schedule_list}")
         sa_schedule_list_valid = self.validate_sa_schedule_list(
             sa_schedule_list, departure_time
         )
-
+        logger.debug(f"sa_schedule_list_valid : {sa_schedule_list_valid}")
         if (
             sa_schedule_list_valid
             and self.comm_session.ev_session_context.sa_schedule_tuple_id

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -1349,32 +1349,27 @@ class ChargeParameterDiscovery(StateSECC):
             return
 
         evse_data_context = self.comm_session.evse_controller.evse_data_context
-        logger.debug(f"evse_data_context : {evse_data_context.__dict__}")
         ev_data_context = self.comm_session.evse_controller.ev_data_context
-        logger.debug(f"ev_data_context : {ev_data_context.__dict__}")
+
         self.comm_session.selected_energy_mode = charge_params_req.requested_energy_mode
-        logger.debug(f"selected_energy_mode : {self.comm_session.selected_energy_mode}")
         self.comm_session.selected_charging_type_is_ac = (
             self.comm_session.selected_energy_mode.value.startswith("AC")
         )
-        logger.debug(f"selected_charging_type_is_ac : {self.comm_session.selected_charging_type_is_ac}")
+
         max_schedule_entries: Optional[
             int
         ] = charge_params_req.max_entries_sa_schedule_tuple
-        logger.debug(f"max_schedule_entries : {max_schedule_entries}")
+
         ac_evse_charge_params: Optional[ACEVSEChargeParameter] = None
         dc_evse_charge_params: Optional[DCEVSEChargeParameter] = None
         if charge_params_req.ac_ev_charge_parameter:
             ac_evse_charge_params = (
                 await self.comm_session.evse_controller.get_ac_charge_params_v2()
             )
-            logger.debug(f"ac_evse_charge_params : {ac_evse_charge_params}")
             evse_data_context.update_ac_charge_parameters_v2(ac_evse_charge_params)
             ev_data_context.update_ac_charge_parameters_v2(
                 charge_params_req.ac_ev_charge_parameter
             )
-            logger.debug(f"update_ac_charge_parameters_v2 : {evse_data_context.__dict__}")
-            logger.debug(f"update_ac_charge_parameters_v2 : {ev_data_context.__dict__}")
         else:
             dc_evse_charge_params = (
                 await self.comm_session.evse_controller.get_dc_charge_parameters_v2()
@@ -1387,18 +1382,17 @@ class ChargeParameterDiscovery(StateSECC):
         departure_time = (
             ev_data_context.departure_time if ev_data_context.departure_time else 0
         )
-        logger.debug(f"departure_time : {departure_time}")
         sa_schedule_list = await self.comm_session.evse_controller.get_sa_schedule_list(
             ev_data_context,
             self.comm_session.config.free_charging_service,
             max_schedule_entries,
             departure_time,
         )
-        logger.debug(f"sa_schedule_list : {sa_schedule_list}")
+
         sa_schedule_list_valid = self.validate_sa_schedule_list(
             sa_schedule_list, departure_time
         )
-        logger.debug(f"sa_schedule_list_valid : {sa_schedule_list_valid}")
+
         if (
             sa_schedule_list_valid
             and self.comm_session.ev_session_context.sa_schedule_tuple_id

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -1349,9 +1349,9 @@ class ChargeParameterDiscovery(StateSECC):
             return
 
         evse_data_context = self.comm_session.evse_controller.evse_data_context
-        logger.debug(f"evse_data_context : {evse_data_context}")
+        logger.debug(f"evse_data_context : {evse_data_context.__dict__}")
         ev_data_context = self.comm_session.evse_controller.ev_data_context
-        logger.debug(f"ev_data_context : {ev_data_context}")
+        logger.debug(f"ev_data_context : {ev_data_context.__dict__}")
         self.comm_session.selected_energy_mode = charge_params_req.requested_energy_mode
         logger.debug(f"selected_energy_mode : {self.comm_session.selected_energy_mode}")
         self.comm_session.selected_charging_type_is_ac = (
@@ -1373,8 +1373,8 @@ class ChargeParameterDiscovery(StateSECC):
             ev_data_context.update_ac_charge_parameters_v2(
                 charge_params_req.ac_ev_charge_parameter
             )
-            logger.debug(f"update_ac_charge_parameters_v2 : {evse_data_context}")
-            logger.debug(f"update_ac_charge_parameters_v2 : {ev_data_context}")
+            logger.debug(f"update_ac_charge_parameters_v2 : {evse_data_context.__dict__}")
+            logger.debug(f"update_ac_charge_parameters_v2 : {ev_data_context.__dict__}")
         else:
             dc_evse_charge_params = (
                 await self.comm_session.evse_controller.get_dc_charge_parameters_v2()


### PR DESCRIPTION
it is discovered in Testival Arnham that it is picking up the maximum voltage from DC even if it is a AC station. the error was: 
`2024-01-30 09:56:07,717  INFO	 - iso15118_service.evse_controller (1727): Session ended in ChargeParameterDiscovery (TypeError occurred while processing message  in state ChargeParameterDiscovery : int() argument must be a string, a bytes-like object or a real number, not 'NoneType'. ).`