### PR TITLE
Fix for ChargeParameterDiscovery  get_evse_max_voltage

### DIFF
--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -786,7 +786,10 @@ class EVSEControllerInterface(ABC):
         - ISO 15118-2
         """
         session_limits = self.evse_data_context.session_limits
-        voltage_limit = session_limits.dc_limits.max_voltage
+        if self.evse_data_context.current_type == CurrentType.AC:
+            voltage_limit = self.evse_data_context.nominal_voltage
+        else:
+            voltage_limit = session_limits.dc_limits.max_voltage
         exponent, value = PhysicalValue.get_exponent_value_repr(voltage_limit)
         return PVEVSEMaxVoltageLimit(
             multiplier=exponent,

--- a/poetry.lock
+++ b/poetry.lock
@@ -502,18 +502,18 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.1.0"
+version = "4.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
-    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
+    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
+    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
 
 [[package]]
 name = "pluggy"

--- a/tests/shared/messages/test_interface.py
+++ b/tests/shared/messages/test_interface.py
@@ -11,6 +11,7 @@ from iso15118.secc.controller.interface import EVSEControllerInterface
 from iso15118.shared.messages.datatypes import (
     PVEVSEMaxCurrent,
     PVEVSEMaxCurrentLimit,
+    PVEVSEMaxVoltageLimit,
     UnitSymbol,
 )
 
@@ -206,4 +207,30 @@ class TestEVSEControllerInterface:
         )
         limit = await evse_controller_interface.get_evse_max_current_limit()
         assert isinstance(limit, PVEVSEMaxCurrent)
+        assert limit == expected_limit
+
+    async def test_get_evse_max_voltage_limit_ac(self, evse_controller_interface):
+        evse_controller_interface.evse_data_context.current_type = CurrentType.AC
+        evse_controller_interface.evse_data_context.nominal_voltage = 230
+        expected_limit = PVEVSEMaxVoltageLimit(
+            multiplier=0,
+            value=230,
+            unit=UnitSymbol.VOLTAGE,
+        )
+        limit = await evse_controller_interface.get_evse_max_voltage_limit()
+        assert isinstance(limit, PVEVSEMaxVoltageLimit)
+        assert limit == expected_limit
+
+    async def test_get_evse_max_voltage_limit_dc(self, evse_controller_interface):
+        evse_controller_interface.evse_data_context.current_type = CurrentType.DC
+        evse_controller_interface.evse_data_context.session_limits.dc_limits.max_voltage = (
+            1000
+        )
+        expected_limit = PVEVSEMaxVoltageLimit(
+            multiplier=0,
+            value=1000,
+            unit=UnitSymbol.VOLTAGE,
+        )
+        limit = await evse_controller_interface.get_evse_max_voltage_limit()
+        assert isinstance(limit, PVEVSEMaxVoltageLimit)
         assert limit == expected_limit


### PR DESCRIPTION
Fix for ChargeParameterDiscovery (TypeError occurred while processing message in state ChargeParameterDiscovery : int() argument must be a string, a bytes-like object or a real number, not 'NoneType'. )

Thank you @ikaratass for finding out where the bug was located and for the initial fix