### PR TITLE
Fixes for issue where the saved session context wasn't found on waking up.

### DIFF
--- a/iso15118/secc/comm_session_handler.py
+++ b/iso15118/secc/comm_session_handler.py
@@ -79,6 +79,7 @@ class SECCCommunicationSession(V2GCommunicationSession):
         config: Config,
         evse_controller: EVSEControllerInterface,
         evse_id: str,
+        ev_session_context: Optional[EVSessionContext15118] = None,
     ):
         # Need to import here to avoid a circular import error
         # pylint: disable=import-outside-toplevel
@@ -93,6 +94,10 @@ class SECCCommunicationSession(V2GCommunicationSession):
         self.evse_controller = evse_controller
         # EVSE ID associated with this session
         self.evse_id = evse_id
+        # EV Session context associated if available.
+        self.ev_session_context: EVSessionContext15118 = (
+            ev_session_context or EVSessionContext15118()
+        )
         # The authorization option(s) offered with ServiceDiscoveryRes in
         # ISO 15118-2 and with AuthorizationSetupRes in ISO 15118-20
         self.offered_auth_options: Optional[List[AuthEnum]] = []
@@ -133,7 +138,6 @@ class SECCCommunicationSession(V2GCommunicationSession):
         # CurrentDemandRes. The SECC must send a copy in the MeteringReceiptReq
         # TODO Add support for ISO 15118-20 MeterInfo
         self.sent_meter_info: Optional[MeterInfoV2] = None
-        self.ev_session_context: EVSessionContext15118 = EVSessionContext15118()
         self.is_tls = self._is_tls(transport)
 
     def save_session_info(self):
@@ -283,8 +287,16 @@ class CommunicationSessionHandler:
                     )
 
                     try:
-                        comm_session, task = self.comm_sessions[notification.ip_address]
-                        comm_session.resume()
+                        comm_session, _ = self.comm_sessions[notification.ip_address[0]]
+                        ev_context = comm_session.ev_session_context
+                        comm_session = SECCCommunicationSession(
+                            notification.transport,
+                            self._rcv_queue,
+                            self.config,
+                            self.evse_controller,
+                            await self.evse_controller.get_evse_id(Protocol.UNKNOWN),
+                            ev_context,
+                        )
                     except (KeyError, ConnectionResetError) as e:
                         if isinstance(e, ConnectionResetError):
                             logger.info("Can't resume session. End and start new one.")
@@ -304,7 +316,10 @@ class CommunicationSessionHandler:
                             Timeouts.V2G_EVCC_COMMUNICATION_SETUP_TIMEOUT
                         )
                     )
-                    self.comm_sessions[notification.ip_address] = (comm_session, task)
+                    self.comm_sessions[notification.ip_address[0]] = (
+                        comm_session,
+                        task,
+                    )
                     self._current_peer_ip = notification.ip_address
                 elif isinstance(notification, StopNotification):
                     try:
@@ -339,19 +354,19 @@ class CommunicationSessionHandler:
             logger.warning(f"Error while indicating EOF to transport reader: {e}")
 
     async def end_current_session(
-        self, peer_ip_address: str, session_stop_action: SessionStopAction
+        self, peer_ip_address: Any, session_stop_action: SessionStopAction
     ):
         try:
             await cancel_task(self.tcp_server_handler)
-            await cancel_task(self.comm_sessions[peer_ip_address][1])
+            await cancel_task(self.comm_sessions[peer_ip_address[0]][1])
         except Exception as e:
             logger.warning(f"Unexpected error ending current session: {e}")
         finally:
             if session_stop_action == SessionStopAction.TERMINATE:
-                del self.comm_sessions[peer_ip_address]
+                del self.comm_sessions[peer_ip_address[0]]
             else:
-                logger.debug(
-                    f"Preserved session state: {self.comm_sessions[peer_ip_address][0].ev_session_context}"  # noqa
+                logger.info(
+                    f"Preserved session state: {self.comm_sessions[peer_ip_address[0]][0].ev_session_context}"  # noqa
                 )
 
         self.tcp_server_handler = None

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -189,7 +189,7 @@ class SessionSetup(StateSECC):
             and msg.header.session_id == self.comm_session.ev_session_context.session_id
         ):
             # The EV wants to resume the previously paused charging session
-            session_id = self.comm_session.session_id
+            session_id = self.comm_session.ev_session_context.session_id
             self.response_code = ResponseCode.OK_OLD_SESSION_JOINED
         else:
             # False session ID from EV, gracefully assigning new session ID


### PR DESCRIPTION
Changed the key to comm_sessions dict in secc comm sessions controller. The new key now uses the IP of the ev. 