### PR TITLE
Moved contactor status check for dc to be after cable check

### DIFF
--- a/iso15118/secc/states/din_spec_states.py
+++ b/iso15118/secc/states/din_spec_states.py
@@ -470,18 +470,6 @@ class CableCheck(StateSECC):
         if not self.cable_check_req_was_received:
             # First CableCheckReq received. Start cable check.
             await self.comm_session.evse_controller.start_cable_check()
-
-            # Requirement in 6.4.3.106 of the IEC 61851-23
-            # Any relays in the DC output circuit of the DC station shall
-            # be closed during the insulation test
-            if not await self.comm_session.evse_controller.is_contactor_closed():
-                self.stop_state_machine(
-                    "Contactor didnt close for Cable Check",
-                    message,
-                    ResponseCode.FAILED,
-                )
-                return
-
             self.cable_check_req_was_received = True
 
         self.comm_session.evse_controller.ev_data_context.present_soc = (
@@ -503,6 +491,17 @@ class CableCheck(StateSECC):
             IsolationLevel.VALID,
             IsolationLevel.WARNING,
         ]:
+            # Requirement in 6.4.3.106 of the IEC 61851-23
+            # Any relays in the DC output circuit of the DC station shall
+            # be closed during the insulation test
+            if not await self.comm_session.evse_controller.is_contactor_closed():
+                self.stop_state_machine(
+                    "Contactor didnt close for Cable Check",
+                    message,
+                    ResponseCode.FAILED,
+                )
+                return
+
             if isolation_level == IsolationLevel.WARNING:
                 logger.warning(
                     "Isolation resistance measured by EVSE is in Warning-Range"

--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -1609,7 +1609,15 @@ class DCCableCheck(StateSECC):
         if not self.cable_check_req_was_received:
             # First DCCableCheckReq received. Start cable check.
             await self.comm_session.evse_controller.start_cable_check()
+            self.cable_check_req_was_received = True
 
+        next_state = None
+        processing = EVSEProcessing.ONGOING
+        isolation_level = (
+            await self.comm_session.evse_controller.get_cable_check_status()
+        )
+
+        if isolation_level in [IsolationLevel.VALID, IsolationLevel.WARNING]:
             # Requirement in 6.4.3.106 of the IEC 61851-23
             # Any relays in the DC output circuit of the DC station shall
             # be closed during the insulation test
@@ -1621,15 +1629,6 @@ class DCCableCheck(StateSECC):
                 )
                 return
 
-            self.cable_check_req_was_received = True
-
-        next_state = None
-        processing = EVSEProcessing.ONGOING
-        isolation_level = (
-            await self.comm_session.evse_controller.get_cable_check_status()
-        )
-
-        if isolation_level in [IsolationLevel.VALID, IsolationLevel.WARNING]:
             if isolation_level == IsolationLevel.WARNING:
                 logger.warning(
                     "Isolation resistance measured by EVSE is in Warning range"

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -2216,18 +2216,6 @@ class CableCheck(StateSECC):
         if not self.cable_check_req_was_received:
             # First CableCheckReq received. Start cable check.
             await self.comm_session.evse_controller.start_cable_check()
-
-            # Requirement in 6.4.3.106 of the IEC 61851-23
-            # Any relays in the DC output circuit of the DC station shall
-            # be closed during the insulation test
-            if not await self.comm_session.evse_controller.is_contactor_closed():
-                self.stop_state_machine(
-                    "Contactor didnt close for Cable Check",
-                    message,
-                    ResponseCode.FAILED,
-                )
-                return
-
             self.cable_check_req_was_received = True
 
         self.comm_session.evse_controller.ev_data_context.present_soc = (
@@ -2244,6 +2232,17 @@ class CableCheck(StateSECC):
             IsolationLevel.VALID,
             IsolationLevel.WARNING,
         ]:
+            # Requirement in 6.4.3.106 of the IEC 61851-23
+            # Any relays in the DC output circuit of the DC station shall
+            # be closed during the insulation test
+            if not await self.comm_session.evse_controller.is_contactor_closed():
+                self.stop_state_machine(
+                    "Contactor didnt close for Cable Check",
+                    message,
+                    ResponseCode.FAILED,
+                )
+                return
+
             if isolation_level == IsolationLevel.WARNING:
                 logger.warning(
                     "Isolation resistance measured by EVSE is in Warning-Range"

--- a/tests/iso15118_20/secc/test_iso15118_20_dc_states.py
+++ b/tests/iso15118_20/secc/test_iso15118_20_dc_states.py
@@ -212,7 +212,7 @@ class TestEvScenarios:
         "cable_check_status, "
         "expected_state",
         [
-            (False, False, None, Terminate),
+            (False, False, IsolationLevel.VALID, Terminate),
             (False, True, None, None),
             (False, True, IsolationLevel.VALID, DCPreCharge),
             (True, True, None, None),


### PR DESCRIPTION
Moved contactor status check for dc to be after a cable check response has been received.