### PR TITLE
fix typo in SECC interface.py

### DIFF
--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -680,7 +680,7 @@ class EVSEControllerInterface(ABC):
         self, protocol: Protocol
     ) -> Union[PVEVSEPresentCurrent, RationalNumber]:
         """
-        Gets the presently available voltage at the EVSE
+        Gets the presently available current at the EVSE
 
         Relevant for:
         - ISO 15118-2


### PR DESCRIPTION
Just a small typo I found when planning the integration into a research project.

(force pushed to rebase change on top of current upstream master)