### PR TITLE
Share display params with CS.

### DIFF
--- a/iso15118/secc/controller/interface.py
+++ b/iso15118/secc/controller/interface.py
@@ -1056,3 +1056,10 @@ class EVSEControllerInterface(ABC):
         Indicate the reason for stopping charging.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    async def send_display_params(self):
+        """
+        Share display params with CS.
+        """
+        raise NotImplementedError

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -1090,3 +1090,9 @@ class SimEVSEController(EVSEControllerInterface):
         @param last_message: The last message that was either sent/received.
         """
         logger.info(f"Session ended in {current_state} ({reason}).")
+
+    async def send_display_params(self):
+        """
+        Share display params with CS.
+        """
+        pass

--- a/iso15118/secc/controller/simulator.py
+++ b/iso15118/secc/controller/simulator.py
@@ -1095,4 +1095,4 @@ class SimEVSEController(EVSEControllerInterface):
         """
         Share display params with CS.
         """
-        pass
+        logger.info("Send display params to CS.")

--- a/iso15118/secc/states/din_spec_states.py
+++ b/iso15118/secc/states/din_spec_states.py
@@ -840,7 +840,7 @@ class CurrentDemand(StateSECC):
                 await self.comm_session.evse_controller.get_evse_max_power_limit()
             ),
         )
-
+        await self.comm_session.evse_controller.send_display_params()
         self.create_next_message(
             None,
             current_demand_res,

--- a/iso15118/secc/states/iso15118_20_states.py
+++ b/iso15118/secc/states/iso15118_20_states.py
@@ -1473,7 +1473,7 @@ class ACChargeLoop(StateSECC):
             ),
             meter_info=meter_info,
         )
-
+        await self.comm_session.evse_controller.send_display_params()
         self.create_next_message(
             None,
             ac_charge_loop_res,
@@ -1798,7 +1798,7 @@ class DCChargeLoop(StateSECC):
                 ResponseCode.FAILED,
             )
             return
-
+        await self.comm_session.evse_controller.send_display_params()
         dc_charge_loop_res = await self._build_dc_charge_loop_res(
             dc_charge_loop_req.meter_info_requested
         )

--- a/iso15118/secc/states/iso15118_2_states.py
+++ b/iso15118/secc/states/iso15118_2_states.py
@@ -2444,6 +2444,8 @@ class CurrentDemand(StateSECC):
             )
             return
 
+        await self.comm_session.evse_controller.send_display_params()
+
         # We don't care about signed meter values from the EVCC, but if you
         # do, then set receipt_required to True and set the field meter_info
         evse_controller = self.comm_session.evse_controller

--- a/tests/shared/messages/test_interface.py
+++ b/tests/shared/messages/test_interface.py
@@ -140,6 +140,9 @@ class DummyEVSEControllerInterface(EVSEControllerInterface):
     async def session_ended(self, _):
         pass
 
+    async def send_display_params(self):
+        pass
+
 
 @pytest.fixture
 def evse_controller_interface():


### PR DESCRIPTION
Share display params coming from EV with the CS. This doesn't apply to -2 AC though - as the request is empty.