### PR TITLE
Allow seconds and minutes for time field units

### DIFF
--- a/iso15118/shared/messages/datatypes.py
+++ b/iso15118/shared/messages/datatypes.py
@@ -322,7 +322,7 @@ class PVRemainingTimeToBulkSOC(PhysicalValue):
     Table 68 shows a max value of 172800 for RemainingTimeToBulkSOC.
     """
 
-    unit: Literal[UnitSymbol.SECONDS] = Field(..., alias="Unit")
+    unit: Literal[UnitSymbol.SECONDS, UnitSymbol.MINUTES] = Field(..., alias="Unit")
 
 
 class PVRemainingTimeToFullSOC(PhysicalValue):
@@ -332,7 +332,7 @@ class PVRemainingTimeToFullSOC(PhysicalValue):
     Table 68 shows a max value of 172800 for RemainingTimeToFullSOC.
     """
 
-    unit: Literal[UnitSymbol.SECONDS] = Field(..., alias="Unit")
+    unit: Literal[UnitSymbol.SECONDS, UnitSymbol.MINUTES] = Field(..., alias="Unit")
 
 
 class PVStartValue(PhysicalValue):
@@ -525,7 +525,7 @@ class PVRemainingTimeToFullSOCDin(PVRemainingTimeToFullSOC):
     In DIN the Element unit is optional, in ISO it is mandatory.
     """
 
-    unit: Literal[UnitSymbol.SECONDS] = Field(None, alias="Unit")
+    unit: Literal[UnitSymbol.SECONDS, UnitSymbol.MINUTES] = Field(None, alias="Unit")
 
 
 class PVRemainingTimeToBulkSOCDin(PVRemainingTimeToBulkSOC):
@@ -535,7 +535,7 @@ class PVRemainingTimeToBulkSOCDin(PVRemainingTimeToBulkSOC):
     In DIN the Element unit is optional, in ISO it is mandatory.
     """
 
-    unit: Literal[UnitSymbol.SECONDS] = Field(None, alias="Unit")
+    unit: Literal[UnitSymbol.SECONDS, UnitSymbol.MINUTES] = Field(None, alias="Unit")
 
 
 class DCEVChargeParams(BaseModel):


### PR DESCRIPTION
When testing charging communication with [our university charging station](https://github.com/securityinmobility/dc-charging-station) and a Maxus eDeliver 3 the iso15118 stack aborts communication with the following error:

```
INFO    2025-04-02 10:08:20,606 - iso15118.shared.exi_codec (302): Decoded message (ns=Namespace.DIN_MSG_DEF): {"V2G_Message":{"Header":{"SessionID":"901BC9A25E58CA06"},"Body":{"CurrentDemandReq":{"DC_EVStatus":{"EVReady":true,"EVErrorCode":"NO_ERROR","EVRESSSOC":66},"EVTargetCurrent":{"Multiplier":-1,"Unit":"A","Value":78},"EVMaximumVoltageLimit":{"Multiplier":-1,"Value":3834},"ChargingComplete":false,"RemainingTimeToFullSoC":{"Multiplier":0,"Unit":"m","Value":30},"EVTargetVoltage":{"Multiplier":-1,"Unit":"V","Value":3834}}}}}
Traceback (most recent call last):
  File "/home/jakob/git/dc-charging-station/venv/lib/python3.11/site-packages/iso15118/shared/exi_codec.py", line 316, in from_exi
    return V2GMessageDINSPEC.parse_obj(decoded_dict["V2G_Message"])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pydantic/main.py", line 526, in pydantic.main.BaseModel.parse_obj
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for V2GMessage
Body -> CurrentDemandReq -> RemainingTimeToFullSoC -> Unit
  unexpected value; permitted: <UnitSymbol.SECONDS: 's'> (type=value_error.const; given=m; permitted=(<UnitSymbol.SECONDS: 's'>,))
ERROR    2025-04-02 10:08:20,607 - iso15118.shared.comm_session (212): EXI message (ns=Namespace.DIN_MSG_DEF) where validation failed: 809a022406f2689796328190d140108080c1380227d0e8c030101e110287d0e800
```

Apparently the `"RemainingTimeToFullSoC":{"Multiplier":0,"Unit":"m","Value":30}` is deemed invalid because of the unit `m` for minutes instead of `s` for seconds.

This pull requests simply allows both units for time fields. I did not check with the DIN SPEC / ISO15118 standard if this is actually valid though.

![image](https://github.com/user-attachments/assets/13665192-8c2f-488c-9630-507a551b17e6)
