### PR TITLE
fix: disable SNI hostname for TLS over IPv6 link-local addresses

### DIFF
--- a/iso15118/evcc/transport/tcp_client.py
+++ b/iso15118/evcc/transport/tcp_client.py
@@ -50,6 +50,7 @@ class TCPClient(asyncio.Protocol):
                 port=port,
                 family=socket.AF_INET6,
                 ssl=self.ssl_context,
+                server_hostname='' if self.ssl_context else None,
             )
         except ConnectionRefusedError as exc:
             raise exc


### PR DESCRIPTION
## Summary

When using TLS over IPv6 link-local addresses, `asyncio.open_connection()` sends the raw IPv6 address (e.g., `fe80::1%lo0`) as the TLS SNI hostname. This violates [RFC 6066 §3](https://www.rfc-editor.org/rfc/rfc6066#section-3), which specifies that the SNI `HostName` field must contain a DNS hostname, not an IP literal.

TLS libraries that strictly validate SNI — such as [rustls](https://github.com/rustls/rustls) — reject the handshake with an `illegal_parameter` alert (SSL error `SSLV3_ALERT_ILLEGAL_PARAMETER`).

## Root Cause

In `iso15118/evcc/transport/tcp_client.py`, `asyncio.open_connection()` is called with `ssl=self.ssl_context` but no explicit `server_hostname`. Python defaults to using the `host` parameter (`fe80::1%lo0`) as the SNI hostname. The string `fe80::1%lo0` fails both DNS name parsing and IP address parsing (due to the `%lo0` scope ID), so strict TLS implementations treat it as an invalid SNI payload and abort.

## Fix

Pass `server_hostname=''` when an SSL context is active. This tells Python to perform the TLS handshake **without** sending an SNI extension, which is the correct behavior when connecting by IP address — SNI is only meaningful for hostname-based virtual hosting.

```python
self.reader, self.writer = await asyncio.open_connection(
    host=full_host_address,
    port=port,
    family=socket.AF_INET6,
    ssl=self.ssl_context,
    server_hostname='' if self.ssl_context else None,  # <-- fix
)
```

## Verification

Tested against both rustls 0.23 (Rust TLS server) and OpenSSL (Python TLS server) over IPv6 link-local loopback (`lo0`). Full ISO 15118-2 PnC AC charging session completes successfully over TLS 1.3:

```
TLS 1.3 Handshake → SupportedAppProtocol → SessionSetup → ServiceDiscovery
→ PaymentServiceSelection → Authorization → ChargeParameterDiscovery
→ PowerDelivery(Start) → ChargingStatus(×10) → PowerDelivery(Stop) → SessionStop
```

## References

- [RFC 6066 §3 — Server Name Indication](https://www.rfc-editor.org/rfc/rfc6066#section-3): *"HostName" contains the fully qualified DNS hostname of the server*
- [Python asyncio.open_connection docs](https://docs.python.org/3/library/asyncio-stream.html#asyncio.open_connection): *server_hostname sets or overrides the hostname that the target server's certificate will be matched against*
- [rustls SNI validation (hs.rs)](https://github.com/rustls/rustls/blob/main/rustls/src/server/hs.rs): rejects `ServerNamePayload::Invalid` with `IllegalParameter`