### PR TITLE
Fix evcc_config_pnc_dc.json: useTls must be true for PnC

### DIFF
--- a/iso15118/shared/examples/evcc/iso15118_2/evcc_config_pnc_dc.json
+++ b/iso15118/shared/examples/evcc/iso15118_2/evcc_config_pnc_dc.json
@@ -7,6 +7,6 @@
 	],
 	"energyTransferMode": "DC_extended",
 	"isCertInstallNeeded": false,
-	"useTls": false,
+	"useTls": true,
 	"chargeLoopCycle": 10
 }


### PR DESCRIPTION
## Summary

- `iso15118/shared/examples/evcc/iso15118_2/evcc_config_pnc_dc.json` had `"useTls": false`, which makes the EVCC silently fall back to EIM. The file's name says PnC but its behaviour is EIM.
- Flip `useTls` to `true` so the example actually exercises the PnC-DC path.

## Why

EVCC's auth-mode selector picks PnC only when *both* the SECC offers `PNC_V2` *and* the connection is TLS:

https://github.com/EcoG-io/iso15118/blob/master/iso15118/evcc/states/iso15118_2_states.py#L276

With `useTls=false`, the SDP request goes out as `NO_TLS`, the SECC's auth-options gate at `iso15118_2_states.py:336` therefore omits PNC, and the EVCC falls back to `AuthEnum.EIM_V2`. End result: `evcc_config_pnc_dc.json` exercises the EIM path and is byte-identical to `evcc_config_eim_dc.json`.

```
$ diff evcc_config_eim_dc.json evcc_config_pnc_dc.json
(empty)
```

The AC variant of this config (`evcc_config_pnc_ac.json`) already has `useTls: true`, so this brings DC into line with its sibling.

## Test plan

- [x] Verified locally against an external SECC (with `SECC_ENFORCE_TLS=True`, `AUTH_MODES=EIM,PNC`): EVCC selects `PNC_V2`, reaches `PaymentDetailsReq` with the contract chain, completes the session through `SessionStop`.
- [x] `evcc_config_eim_dc.json` is unchanged — anyone wanting the silent-EIM-fallback behaviour can use it directly.
- [x] No other examples reference `evcc_config_pnc_dc.json`.