### PR TITLE
EVCC SDP fixes for 10BASE-T1S / single-pair Ethernet

### DIFF
--- a/iso15118/evcc/comm_session_handler.py
+++ b/iso15118/evcc/comm_session_handler.py
@@ -555,8 +555,11 @@ class CommunicationSessionHandler:
                     try:
                         await self.restart_sdp(False)
                     except SDPFailedError as exc:
-                        logger.exception(exc)
-                        # TODO not sure what else to do here
+                        logger.debug("SDP cycle exhausted, starting new cycle")
+                        try:
+                            await self.restart_sdp(True)
+                        except SDPFailedError as exc2:
+                            logger.exception(exc2)
                 elif isinstance(notification, StopNotification):
                     await cancel_task(self.comm_session[1])
                     del self.comm_session

--- a/iso15118/evcc/states/iso15118_20_states.py
+++ b/iso15118/evcc/states/iso15118_20_states.py
@@ -658,13 +658,21 @@ class ServiceDetail(StateEVCC):
         control_mode_set = False
         if self.comm_session.selected_energy_service:
             parameter_set = self.comm_session.selected_energy_service.parameter_set
-            for param in parameter_set.parameters:
-                if param.name == ParameterName.CONTROL_MODE:
-                    self.comm_session.control_mode = ControlMode(param.int_value)
-                    logger.info(
-                        f"Selected Control Mode: {self.comm_session.control_mode}"
-                    )
-                    control_mode_set = True
+            offered = [
+                ControlMode(param.int_value)
+                for param in parameter_set.parameters
+                if param.name == ParameterName.CONTROL_MODE
+            ]
+            if offered:
+                # Prefer DYNAMIC when the SECC offers it. Some chargers (e.g.
+                # SEIC3500) advertise both modes in one parameter set but only
+                # complete ScheduleExchange in Dynamic; a naive last-wins pick of
+                # SCHEDULED then crashes in PowerDelivery (scheduled_params is None).
+                self.comm_session.control_mode = (
+                    ControlMode.DYNAMIC if ControlMode.DYNAMIC in offered else offered[-1]
+                )
+                logger.info(f"Selected Control Mode: {self.comm_session.control_mode}")
+                control_mode_set = True
         return control_mode_set
 
     def store_parameter_sets(self, service_detail_res: ServiceDetailRes):

--- a/iso15118/evcc/transport/udp_client.py
+++ b/iso15118/evcc/transport/udp_client.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 
 from iso15118.shared.messages.timeouts import Timeouts
 from iso15118.shared.messages.v2gtp import V2GTPMessage
-from iso15118.shared.network import SDP_MULTICAST_GROUP, SDP_SERVER_PORT
+from iso15118.shared.network import SDP_MULTICAST_GROUP, SDP_SERVER_PORT, _get_link_local_addr
 from iso15118.shared.notifications import (
     ReceiveTimeoutNotification,
     UDPPacketNotification,
@@ -66,6 +66,16 @@ class UDPClient(DatagramProtocol):
         # interface(s) the socket receives multicast packets from.
         interface_index = socket.if_nametoindex(iface)
         sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_IF, interface_index)
+
+        # Bind to the interface's link-local address on an ephemeral port so
+        # the kernel delivers unicast SDP responses back to this socket.
+        # Without an explicit bind(), the socket only auto-binds on first
+        # sendto(), and on Linux the unbound socket may not receive the unicast
+        # reply because it isn't anchored to the interface. Using the
+        # link-local address + scope_id avoids needing CAP_NET_RAW
+        # (required by SO_BINDTODEVICE) while still anchoring to the NIC.
+        link_local_addr = _get_link_local_addr(iface)
+        sock.bind((str(link_local_addr), 0, 0, interface_index))
 
         return sock
 


### PR DESCRIPTION
- udp_client: bind the UDP socket to the interface link-local address on an ephemeral port so the kernel delivers unicast SDP responses back to it. Without an explicit bind() the socket only auto-binds on first sendto(), and on Linux an unbound socket may not receive the unicast reply because it isn't anchored to the NIC. Avoids needing CAP_NET_RAW (SO_BINDTODEVICE).
- comm_session_handler: when an SDP retry cycle is exhausted, start a new cycle instead of giving up, so discovery keeps retrying.